### PR TITLE
Annotations and Comment from formatter/jdk.astub

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -26,6 +26,8 @@
 package java.io;
 
 import org.checkerframework.checker.formatter.qual.FormatMethod;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.util.*;
 import java.nio.charset.Charset;
 import jdk.internal.misc.JavaIOAccess;
@@ -92,6 +94,7 @@ import sun.nio.cs.StreamEncoder;
  * @since   1.6
  */
 
+@AnnotatedFor("formatter")
 public final class Console implements Flushable
 {
    /**

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import org.checkerframework.checker.formatter.qual.FormatMethod;
 import java.util.*;
 import java.nio.charset.Charset;
 import jdk.internal.misc.JavaIOAccess;
@@ -168,6 +169,7 @@ public final class Console implements Flushable
     *
     * @return  This console
     */
+    @FormatMethod
     public Console format(String fmt, Object ...args) {
         formatter.format(fmt, args).flush();
         return this;
@@ -208,6 +210,7 @@ public final class Console implements Flushable
     *
     * @return  This console
     */
+    @FormatMethod
     public Console printf(String format, Object ... args) {
         return format(format, args);
     }

--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -26,6 +26,8 @@
 package java.io;
 
 import org.checkerframework.checker.formatter.qual.FormatMethod;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.util.Formatter;
 import java.util.Locale;
 import java.nio.charset.Charset;
@@ -61,6 +63,7 @@ import java.nio.charset.UnsupportedCharsetException;
  * @since      1.0
  */
 
+@AnnotatedFor("formatter")
 public class PrintStream extends FilterOutputStream
     implements Appendable, Closeable
 {

--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import org.checkerframework.checker.formatter.qual.FormatMethod;
 import java.util.Formatter;
 import java.util.Locale;
 import java.nio.charset.Charset;
@@ -945,6 +946,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintStream printf(String format, Object ... args) {
         return format(format, args);
     }
@@ -997,6 +999,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintStream printf(Locale l, String format, Object ... args) {
         return format(l, format, args);
     }
@@ -1042,6 +1045,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintStream format(String format, Object ... args) {
         try {
             synchronized (this) {
@@ -1101,6 +1105,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintStream format(Locale l, String format, Object ... args) {
         try {
             synchronized (this) {

--- a/src/java.base/share/classes/java/io/PrintWriter.java
+++ b/src/java.base/share/classes/java/io/PrintWriter.java
@@ -26,6 +26,8 @@
 package java.io;
 
 import org.checkerframework.checker.formatter.qual.FormatMethod;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.util.Objects;
 import java.util.Formatter;
 import java.util.Locale;
@@ -59,6 +61,7 @@ import java.nio.charset.UnsupportedCharsetException;
  * @since       1.1
  */
 
+@AnnotatedFor("formatter")
 public class PrintWriter extends Writer {
 
     /**

--- a/src/java.base/share/classes/java/io/PrintWriter.java
+++ b/src/java.base/share/classes/java/io/PrintWriter.java
@@ -25,6 +25,7 @@
 
 package java.io;
 
+import org.checkerframework.checker.formatter.qual.FormatMethod;
 import java.util.Objects;
 import java.util.Formatter;
 import java.util.Locale;
@@ -885,6 +886,7 @@ public class PrintWriter extends Writer {
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintWriter printf(String format, Object ... args) {
         return format(format, args);
     }
@@ -938,6 +940,7 @@ public class PrintWriter extends Writer {
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintWriter printf(Locale l, String format, Object ... args) {
         return format(l, format, args);
     }
@@ -982,6 +985,7 @@ public class PrintWriter extends Writer {
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintWriter format(String format, Object ... args) {
         try {
             synchronized (lock) {
@@ -1042,6 +1046,7 @@ public class PrintWriter extends Writer {
      *
      * @since  1.5
      */
+    @FormatMethod
     public PrintWriter format(Locale l, String format, Object ... args) {
         try {
             synchronized (lock) {

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -26,6 +26,8 @@
 package java.lang;
 
 import org.checkerframework.checker.formatter.qual.FormatMethod;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.io.ObjectStreamField;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Native;
@@ -123,6 +125,7 @@ import jdk.internal.vm.annotation.Stable;
  * @jls     15.18.1 String Concatenation Operator +
  */
 
+@AnnotatedFor("formatter")
 public final class String
     implements java.io.Serializable, Comparable<String>, CharSequence {
 

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -25,6 +25,7 @@
 
 package java.lang;
 
+import org.checkerframework.checker.formatter.qual.FormatMethod;
 import java.io.ObjectStreamField;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Native;
@@ -2893,6 +2894,7 @@ public final class String
      * @see  java.util.Formatter
      * @since  1.5
      */
+    @FormatMethod
     public static String format(String format, Object... args) {
         return new Formatter().format(format, args).toString();
     }
@@ -2934,6 +2936,7 @@ public final class String
      * @see  java.util.Formatter
      * @since  1.5
      */
+    @FormatMethod
     public static String format(Locale l, String format, Object... args) {
         return new Formatter(l).format(format, args).toString();
     }

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -25,6 +25,8 @@
 
 package java.util;
 
+import org.checkerframework.checker.formatter.qual.FormatMethod;
+
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.IOException;
@@ -60,8 +62,6 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
-
-import org.checkerframework.checker.formatter.qual.FormatMethod;
 
 import jdk.internal.math.DoubleConsts;
 import jdk.internal.math.FormattedFloatingDecimal;
@@ -1914,6 +1914,7 @@ import sun.util.locale.provider.ResourceBundleBasedAdapter;
  * @author  Iris Clark
  * @since 1.5
  */
+@AnnotatedFor("formatter")
 public final class Formatter implements Closeable, Flushable {
     private Appendable a;
     private final Locale l;

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -61,6 +61,8 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
 
+import org.checkerframework.checker.formatter.qual.FormatMethod;
+
 import jdk.internal.math.DoubleConsts;
 import jdk.internal.math.FormattedFloatingDecimal;
 import sun.util.locale.provider.LocaleProviderAdapter;
@@ -2605,6 +2607,7 @@ public final class Formatter implements Closeable, Flushable {
      *
      * @return  This formatter
      */
+    @FormatMethod
     public Formatter format(String format, Object ... args) {
         return format(l, format, args);
     }
@@ -2644,6 +2647,7 @@ public final class Formatter implements Closeable, Flushable {
      *
      * @return  This formatter
      */
+    @FormatMethod
     public Formatter format(Locale l, String format, Object ... args) {
         ensureOpen();
 


### PR DESCRIPTION
Annotations and Comments from [formatter/jdk.astub](https://github.com/typetools/checker-framework/blob/master/checker/src/main/java/org/checkerframework/checker/formatter/jdk.astub)