### PR TITLE
Remove explicit "extends @Nullable Object."

### DIFF
--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -147,7 +147,7 @@ import jdk.internal.misc.SharedSecrets;
  * @since   1.2
  */
 @AnnotatedFor({"lock", "nullness", "index"})
-public class HashMap<K extends @Nullable Object,V extends @Nullable Object> extends AbstractMap<K,V>
+public class HashMap<K,V> extends AbstractMap<K,V>
     implements Map<K,V>, Cloneable, Serializable {
 
     private static final long serialVersionUID = 362498820763181265L;

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -172,7 +172,7 @@ import java.io.Serializable;
 @CFComment({"lock/nullness: Subclasses of this interface/class may opt to prohibit null elements"})
 @AnnotatedFor({"lock", "nullness", "index"})
 @Covariant({0})
-public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
+public interface Map<K, V> {
     // Query Operations
 
     /**
@@ -437,7 +437,7 @@ public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
      * @since 1.2
      */
     @Covariant({0})
-    interface Entry<K extends @Nullable Object, V extends @Nullable Object> {
+    interface Entry<K, V> {
         /**
          * Returns the key corresponding to this entry.
          *


### PR DESCRIPTION
It is supposed to be a no-op. As such, the stub files usually omit it.

Currently, it actually changes behavior in a bad way:
https://github.com/typetools/checker-framework/issues/2995

Until that bug is fixed, this commit serves as a workaround.