### PR TITLE
firstKey/lastKey return a key into the map.

### DIFF
--- a/src/java.base/share/classes/java/util/SortedMap.java
+++ b/src/java.base/share/classes/java/util/SortedMap.java
@@ -226,7 +226,7 @@ public interface SortedMap<K,V> extends Map<K,V> {
      * @throws NoSuchElementException if this map is empty
      */
     @SideEffectFree
-    K firstKey(@GuardSatisfied SortedMap<K, V> this);
+    @KeyFor("this") K firstKey(@GuardSatisfied SortedMap<K, V> this);
 
     /**
      * Returns the last (highest) key currently in this map.
@@ -235,7 +235,7 @@ public interface SortedMap<K,V> extends Map<K,V> {
      * @throws NoSuchElementException if this map is empty
      */
     @SideEffectFree
-    K lastKey(@GuardSatisfied SortedMap<K, V> this);
+    @KeyFor("this") K lastKey(@GuardSatisfied SortedMap<K, V> this);
 
     /**
      * Returns a {@link Set} view of the keys contained in this map.

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -302,14 +302,14 @@ public class TreeMap<K,V>
     /**
      * @throws NoSuchElementException {@inheritDoc}
      */
-    public K firstKey() {
+    public @KeyFor("this") K firstKey() {
         return key(getFirstEntry());
     }
 
     /**
      * @throws NoSuchElementException {@inheritDoc}
      */
-    public K lastKey() {
+    public @KeyFor("this") K lastKey() {
         return key(getLastEntry());
     }
 


### PR DESCRIPTION
This avoids the following kind of false positive:

```java
import java.util.TreeMap;

class Demo {
  String foo(TreeMap<String, String> m) {
    return m.get(m.firstKey());
  }
}
```

Corresponding CF PR: https://github.com/typetools/checker-framework/pull/3156