### PR TITLE
Remove `@Covariant` from `Map`.

### DIFF
--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -171,7 +171,6 @@ import java.io.Serializable;
  */
 @CFComment({"lock/nullness: Subclasses of this interface/class may opt to prohibit null elements"})
 @AnnotatedFor({"lock", "nullness", "index"})
-@Covariant({0})
 public interface Map<K, V> {
     // Query Operations
 


### PR DESCRIPTION
It, like `List` (https://github.com/typetools/checker-framework/issues/2047), is not covariant:

```
import java.util.HashMap;
import java.util.Map;
import org.checkerframework.checker.nullness.qual.Nullable;

class MapCovariant {
  public static void main(String[] args) {
    Map<String, String> map = new HashMap<String, String>();
    Map<@Nullable String, String> sameMap = map;
    sameMap.put(null, "");
    map.keySet().iterator().next().toString(); // NPE
  }
}
```