### PR TITLE
`@Nullable` annotations on `equals` and collection methods.

### DIFF
--- a/src/java.base/share/classes/java/lang/annotation/Annotation.java
+++ b/src/java.base/share/classes/java/lang/annotation/Annotation.java
@@ -25,6 +25,9 @@
 
 package java.lang.annotation;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * The common interface extended by all annotation types.  Note that an
  * interface that manually extends this one does <i>not</i> define
@@ -41,6 +44,7 @@ package java.lang.annotation;
  * @author  Josh Bloch
  * @since   1.5
  */
+@AnnotatedFor({"nullness"})
 public interface Annotation {
     /**
      * Returns true if the specified object represents an annotation
@@ -78,7 +82,7 @@ public interface Annotation {
      * @return true if the specified object represents an annotation
      *     that is logically equivalent to this one, otherwise false
      */
-    boolean equals(Object obj);
+    boolean equals(@Nullable Object obj);
 
     /**
      * Returns the hash code of this annotation, as defined below:

--- a/src/java.base/share/classes/java/util/EnumMap.java
+++ b/src/java.base/share/classes/java/util/EnumMap.java
@@ -212,7 +212,7 @@ public class EnumMap<K extends Enum<K>, V> extends AbstractMap<K, V>
      * @return {@code true} if this map maps one or more keys to this value
      */
     @Pure
-    public boolean containsValue(Object value) {
+    public boolean containsValue(@Nullable Object value) {
         value = maskNull(value);
 
         for (Object val : vals)
@@ -232,7 +232,7 @@ public class EnumMap<K extends Enum<K>, V> extends AbstractMap<K, V>
      */
     @EnsuresKeyForIf(expression={"#1"}, result=true, map={"this"})
     @Pure
-    public boolean containsKey(Object key) {
+    public boolean containsKey(@Nullable Object key) {
         return isValidKey(key) && vals[((Enum<?>)key).ordinal()] != null;
     }
 
@@ -256,7 +256,7 @@ public class EnumMap<K extends Enum<K>, V> extends AbstractMap<K, V>
      * The {@link #containsKey containsKey} operation may be used to
      * distinguish these two cases.
      */
-    public @Nullable V get(Object key) {
+    public @Nullable V get(@Nullable Object key) {
         return (isValidKey(key) ?
                 unmaskNull(vals[((Enum<?>)key).ordinal()]) : null);
     }

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -604,7 +604,7 @@ public interface Map<K, V> {
      * @param o object to be compared for equality with this map
      * @return {@code true} if the specified object is equal to this map
      */
-    boolean equals(@GuardSatisfied Map<K, V> this, @GuardSatisfied Object o);
+    boolean equals(@GuardSatisfied Map<K, V> this, @GuardSatisfied @Nullable Object o);
 
     /**
      * Returns the hash code value for this map.  The hash code of a map is


### PR DESCRIPTION
Aside from the annotations on `Annotation` (which was not previously
annotated), the other changes here were present in the old stubs but
not propagated to the new stubs:

https://github.com/typetools/checker-framework/blob/869caaab3f2b9c26600f394562dae30099fbc861/checker/jdk/nullness/src/java/util/EnumMap.java#L214
("Attempts to test for the presence of a null key or to remove one will,
however, function properly.")

https://github.com/typetools/checker-framework/blob/869caaab3f2b9c26600f394562dae30099fbc861/checker/jdk/nullness/src/java/util/Map.java#L465