### PR TITLE
Add aliasing annotation

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -63,8 +63,7 @@ public class Object {
      * Constructs a new object.
      */
     @HotSpotIntrinsicCandidate
-    @Unique
-    public Object() {}
+    public @Unique Object() {}
 
     /**
      * Returns the runtime class of this {@code Object}. The returned

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -50,7 +50,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @see     java.lang.Class
  * @since   1.0
  */
-@AnnotatedFor({"guieffect", "index", "lock", "nullness","aliasing"})
+@AnnotatedFor({"guieffect", "index", "lock", "nullness", "aliasing"})
 @PolyUIType
 public class Object {
 

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -50,7 +50,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @see     java.lang.Class
  * @since   1.0
  */
-@AnnotatedFor({"guieffect", "index", "lock", "nullness", "aliasing"})
+@AnnotatedFor({"aliasing", "guieffect", "index", "lock", "nullness"})
 @PolyUIType
 public class Object {
 

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -37,6 +37,7 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.qual.CFComment;
+import org.checkerframework.common.aliasing.qual.Unique;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
 
@@ -49,7 +50,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @see     java.lang.Class
  * @since   1.0
  */
-@AnnotatedFor({"guieffect", "index", "lock", "nullness"})
+@AnnotatedFor({"guieffect", "index", "lock", "nullness","aliasing"})
 @PolyUIType
 public class Object {
 
@@ -62,6 +63,7 @@ public class Object {
      * Constructs a new object.
      */
     @HotSpotIntrinsicCandidate
+    @Unique
     public Object() {}
 
     /**


### PR DESCRIPTION
Alternative fix for issue #3313 in typetools/checker-framework. Annotating Object class as @Unique to remove unnecessary @SuppressWarnings("unique.leaked") annotation on parent class constructors.