### PR TITLE
Improve nullability annotations for PreparedStatement, CallableStatement, ResultSet

### DIFF
--- a/src/java.sql/share/classes/java/sql/CallableStatement.java
+++ b/src/java.sql/share/classes/java/sql/CallableStatement.java
@@ -25,6 +25,8 @@
 
 package java.sql;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import java.math.BigDecimal;
 import java.util.Calendar;
 import java.io.Reader;
@@ -171,7 +173,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method is called on a closed <code>CallableStatement</code>
      * @see #setString
      */
-    String getString(int parameterIndex) throws SQLException;
+    @Nullable String getString(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>BIT</code>
@@ -297,7 +299,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setBigDecimal
      */
     @Deprecated(since="1.2")
-    BigDecimal getBigDecimal(int parameterIndex, int scale)
+    @Nullable BigDecimal getBigDecimal(int parameterIndex, int scale)
         throws SQLException;
 
     /**
@@ -313,7 +315,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method is called on a closed <code>CallableStatement</code>
      * @see #setBytes
      */
-    byte[] getBytes(int parameterIndex) throws SQLException;
+    byte @Nullable [] getBytes(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>DATE</code> parameter as a
@@ -327,7 +329,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method is called on a closed <code>CallableStatement</code>
      * @see #setDate
      */
-    java.sql.Date getDate(int parameterIndex) throws SQLException;
+    java.sql.@Nullable Date getDate(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>TIME</code> parameter as a
@@ -342,7 +344,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method is called on a closed <code>CallableStatement</code>
      * @see #setTime
      */
-    java.sql.Time getTime(int parameterIndex) throws SQLException;
+    java.sql.@Nullable Time getTime(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>TIMESTAMP</code> parameter as a
@@ -357,7 +359,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method is called on a closed <code>CallableStatement</code>
      * @see #setTimestamp
      */
-    java.sql.Timestamp getTimestamp(int parameterIndex)
+    java.sql.@Nullable Timestamp getTimestamp(int parameterIndex)
         throws SQLException;
 
     //----------------------------------------------------------------------
@@ -384,7 +386,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see Types
      * @see #setObject
      */
-    Object getObject(int parameterIndex) throws SQLException;
+    @Nullable Object getObject(int parameterIndex) throws SQLException;
 
 
     //--------------------------JDBC 2.0-----------------------------
@@ -403,7 +405,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setBigDecimal
      * @since 1.2
      */
-    BigDecimal getBigDecimal(int parameterIndex) throws SQLException;
+    @Nullable BigDecimal getBigDecimal(int parameterIndex) throws SQLException;
 
     /**
      * Returns an object representing the value of OUT parameter
@@ -426,7 +428,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setObject
      * @since 1.2
      */
-    Object getObject(int parameterIndex, java.util.Map<String,Class<?>> map)
+    @Nullable Object getObject(int parameterIndex, java.util.Map<String,Class<?>> map)
         throws SQLException;
 
     /**
@@ -444,7 +446,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.2
      */
-    Ref getRef (int parameterIndex) throws SQLException;
+    @Nullable Ref getRef (int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>BLOB</code> parameter as a
@@ -460,7 +462,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.2
      */
-    Blob getBlob (int parameterIndex) throws SQLException;
+    @Nullable Blob getBlob (int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>CLOB</code> parameter as a
@@ -477,7 +479,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.2
      */
-    Clob getClob (int parameterIndex) throws SQLException;
+    @Nullable Clob getClob (int parameterIndex) throws SQLException;
 
     /**
      *
@@ -495,7 +497,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.2
      */
-    Array getArray (int parameterIndex) throws SQLException;
+    @Nullable Array getArray (int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>DATE</code> parameter as a
@@ -519,7 +521,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setDate
      * @since 1.2
      */
-    java.sql.Date getDate(int parameterIndex, Calendar cal)
+    java.sql.@Nullable Date getDate(int parameterIndex, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -544,7 +546,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setTime
      * @since 1.2
      */
-    java.sql.Time getTime(int parameterIndex, Calendar cal)
+    java.sql.@Nullable Time getTime(int parameterIndex, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -570,7 +572,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setTimestamp
      * @since 1.2
      */
-    java.sql.Timestamp getTimestamp(int parameterIndex, Calendar cal)
+    java.sql.@Nullable Timestamp getTimestamp(int parameterIndex, @Nullable Calendar cal)
         throws SQLException;
 
 
@@ -759,7 +761,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setURL
      * @since 1.4
      */
-    java.net.URL getURL(int parameterIndex) throws SQLException;
+    java.net.@Nullable URL getURL(int parameterIndex) throws SQLException;
 
     /**
      * Sets the designated parameter to the given <code>java.net.URL</code> object.
@@ -777,7 +779,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getURL
      * @since 1.4
      */
-    void setURL(String parameterName, java.net.URL val) throws SQLException;
+    void setURL(String parameterName, java.net.@Nullable URL val) throws SQLException;
 
     /**
      * Sets the designated parameter to SQL <code>NULL</code>.
@@ -930,7 +932,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getBigDecimal
      * @since 1.4
      */
-    void setBigDecimal(String parameterName, BigDecimal x) throws SQLException;
+    void setBigDecimal(String parameterName, @Nullable BigDecimal x) throws SQLException;
 
     /**
      * Sets the designated parameter to the given Java <code>String</code> value.
@@ -950,7 +952,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getString
      * @since 1.4
      */
-    void setString(String parameterName, String x) throws SQLException;
+    void setString(String parameterName, @Nullable String x) throws SQLException;
 
     /**
      * Sets the designated parameter to the given Java array of bytes.
@@ -969,7 +971,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getBytes
      * @since 1.4
      */
-    void setBytes(String parameterName, byte x[]) throws SQLException;
+    void setBytes(String parameterName, byte @Nullable [] x) throws SQLException;
 
     /**
      * Sets the designated parameter to the given <code>java.sql.Date</code> value
@@ -988,7 +990,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getDate
      * @since 1.4
      */
-    void setDate(String parameterName, java.sql.Date x)
+    void setDate(String parameterName, java.sql.@Nullable Date x)
         throws SQLException;
 
     /**
@@ -1006,7 +1008,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getTime
      * @since 1.4
      */
-    void setTime(String parameterName, java.sql.Time x)
+    void setTime(String parameterName, java.sql.@Nullable Time x)
         throws SQLException;
 
     /**
@@ -1025,7 +1027,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getTimestamp
      * @since 1.4
      */
-    void setTimestamp(String parameterName, java.sql.Timestamp x)
+    void setTimestamp(String parameterName, java.sql.@Nullable Timestamp x)
         throws SQLException;
 
     /**
@@ -1051,7 +1053,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.4
      */
-    void setAsciiStream(String parameterName, java.io.InputStream x, int length)
+    void setAsciiStream(String parameterName, java.io.@Nullable InputStream x, int length)
         throws SQLException;
 
     /**
@@ -1076,7 +1078,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.4
      */
-    void setBinaryStream(String parameterName, java.io.InputStream x,
+    void setBinaryStream(String parameterName, java.io.@Nullable InputStream x,
                          int length) throws SQLException;
 
     /**
@@ -1114,7 +1116,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getObject
      * @since 1.4
      */
-    void setObject(String parameterName, Object x, int targetSqlType, int scale)
+    void setObject(String parameterName, @Nullable Object x, int targetSqlType, int scale)
         throws SQLException;
 
     /**
@@ -1136,7 +1138,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getObject
      * @since 1.4
      */
-    void setObject(String parameterName, Object x, int targetSqlType)
+    void setObject(String parameterName, @Nullable Object x, int targetSqlType)
         throws SQLException;
 
     /**
@@ -1179,7 +1181,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getObject
      * @since 1.4
      */
-    void setObject(String parameterName, Object x) throws SQLException;
+    void setObject(String parameterName, @Nullable Object x) throws SQLException;
 
 
     /**
@@ -1207,7 +1209,7 @@ public interface CallableStatement extends PreparedStatement {
      * @since 1.4
      */
     void setCharacterStream(String parameterName,
-                            java.io.Reader reader,
+                            java.io.@Nullable Reader reader,
                             int length) throws SQLException;
 
     /**
@@ -1232,7 +1234,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getDate
      * @since 1.4
      */
-    void setDate(String parameterName, java.sql.Date x, Calendar cal)
+    void setDate(String parameterName, java.sql.@Nullable Date x, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -1257,7 +1259,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getTime
      * @since 1.4
      */
-    void setTime(String parameterName, java.sql.Time x, Calendar cal)
+    void setTime(String parameterName, java.sql.@Nullable Time x, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -1282,7 +1284,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #getTimestamp
      * @since 1.4
      */
-    void setTimestamp(String parameterName, java.sql.Timestamp x, Calendar cal)
+    void setTimestamp(String parameterName, java.sql.@Nullable Timestamp x, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -1340,7 +1342,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setString
      * @since 1.4
      */
-    String getString(String parameterName) throws SQLException;
+    @Nullable String getString(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>BIT</code> or <code>BOOLEAN</code>
@@ -1472,7 +1474,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setBytes
      * @since 1.4
      */
-    byte[] getBytes(String parameterName) throws SQLException;
+    byte @Nullable [] getBytes(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>DATE</code> parameter as a
@@ -1488,7 +1490,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setDate
      * @since 1.4
      */
-    java.sql.Date getDate(String parameterName) throws SQLException;
+    java.sql.@Nullable Date getDate(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>TIME</code> parameter as a
@@ -1504,7 +1506,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setTime
      * @since 1.4
      */
-    java.sql.Time getTime(String parameterName) throws SQLException;
+    java.sql.@Nullable Time getTime(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>TIMESTAMP</code> parameter as a
@@ -1520,7 +1522,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setTimestamp
      * @since 1.4
      */
-    java.sql.Timestamp getTimestamp(String parameterName) throws SQLException;
+    java.sql.@Nullable Timestamp getTimestamp(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a parameter as an <code>Object</code> in the Java
@@ -1543,7 +1545,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setObject
      * @since 1.4
      */
-    Object getObject(String parameterName) throws SQLException;
+    @Nullable Object getObject(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>NUMERIC</code> parameter as a
@@ -1560,7 +1562,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setBigDecimal
      * @since 1.4
      */
-    BigDecimal getBigDecimal(String parameterName) throws SQLException;
+    @Nullable BigDecimal getBigDecimal(String parameterName) throws SQLException;
 
     /**
      * Returns an object representing the value of OUT parameter
@@ -1583,7 +1585,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setObject
      * @since 1.4
      */
-    Object getObject(String parameterName, java.util.Map<String,Class<?>> map)
+    @Nullable Object getObject(String parameterName, java.util.Map<String,Class<?>> map)
       throws SQLException;
 
     /**
@@ -1601,7 +1603,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.4
      */
-    Ref getRef (String parameterName) throws SQLException;
+    @Nullable Ref getRef (String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>BLOB</code> parameter as a
@@ -1618,7 +1620,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.4
      */
-    Blob getBlob (String parameterName) throws SQLException;
+    @Nullable Blob getBlob (String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>CLOB</code> parameter as a
@@ -1634,7 +1636,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.4
      */
-    Clob getClob (String parameterName) throws SQLException;
+    @Nullable Clob getClob (String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>ARRAY</code> parameter as an
@@ -1651,7 +1653,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.4
      */
-    Array getArray (String parameterName) throws SQLException;
+    @Nullable Array getArray (String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of a JDBC <code>DATE</code> parameter as a
@@ -1676,7 +1678,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setDate
      * @since 1.4
      */
-    java.sql.Date getDate(String parameterName, Calendar cal)
+    java.sql.@Nullable Date getDate(String parameterName, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -1702,7 +1704,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setTime
      * @since 1.4
      */
-    java.sql.Time getTime(String parameterName, Calendar cal)
+    java.sql.@Nullable Time getTime(String parameterName, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -1729,7 +1731,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setTimestamp
      * @since 1.4
      */
-    java.sql.Timestamp getTimestamp(String parameterName, Calendar cal)
+    java.sql.@Nullable Timestamp getTimestamp(String parameterName, @Nullable Calendar cal)
         throws SQLException;
 
     /**
@@ -1749,7 +1751,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see #setURL
      * @since 1.4
      */
-    java.net.URL getURL(String parameterName) throws SQLException;
+    java.net.@Nullable URL getURL(String parameterName) throws SQLException;
 
     //------------------------- JDBC 4.0 -----------------------------------
 
@@ -1768,7 +1770,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    RowId getRowId(int parameterIndex) throws SQLException;
+    @Nullable RowId getRowId(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated JDBC <code>ROWID</code> parameter as a
@@ -1785,7 +1787,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    RowId getRowId(String parameterName) throws SQLException;
+    @Nullable RowId getRowId(String parameterName) throws SQLException;
 
      /**
      * Sets the designated parameter to the given <code>java.sql.RowId</code> object. The
@@ -1801,7 +1803,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setRowId(String parameterName, RowId x) throws SQLException;
+    void setRowId(String parameterName, @Nullable RowId x) throws SQLException;
 
     /**
      * Sets the designated parameter to the given <code>String</code> object.
@@ -1818,7 +1820,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setNString(String parameterName, String value)
+    void setNString(String parameterName, @Nullable String value)
             throws SQLException;
 
     /**
@@ -1838,7 +1840,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setNCharacterStream(String parameterName, Reader value, long length)
+    void setNCharacterStream(String parameterName, @Nullable Reader value, long length)
             throws SQLException;
 
      /**
@@ -1856,7 +1858,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-     void setNClob(String parameterName, NClob value) throws SQLException;
+     void setNClob(String parameterName, @Nullable NClob value) throws SQLException;
 
     /**
      * Sets the designated parameter to a <code>Reader</code> object.  The <code>reader</code> must contain  the number
@@ -1879,7 +1881,7 @@ public interface CallableStatement extends PreparedStatement {
      *
      * @since 1.6
      */
-     void setClob(String parameterName, Reader reader, long length)
+     void setClob(String parameterName, @Nullable Reader reader, long length)
        throws SQLException;
 
     /**
@@ -1909,7 +1911,7 @@ public interface CallableStatement extends PreparedStatement {
      *
      * @since 1.6
      */
-     void setBlob(String parameterName, InputStream inputStream, long length)
+     void setBlob(String parameterName, @Nullable InputStream inputStream, long length)
         throws SQLException;
     /**
      * Sets the designated parameter to a <code>Reader</code> object.  The <code>reader</code> must contain  the number
@@ -1934,7 +1936,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-     void setNClob(String parameterName, Reader reader, long length)
+     void setNClob(String parameterName, @Nullable Reader reader, long length)
        throws SQLException;
 
     /**
@@ -1955,7 +1957,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    NClob getNClob (int parameterIndex) throws SQLException;
+    @Nullable NClob getNClob (int parameterIndex) throws SQLException;
 
 
     /**
@@ -1974,7 +1976,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    NClob getNClob (String parameterName) throws SQLException;
+    @Nullable NClob getNClob (String parameterName) throws SQLException;
 
     /**
      * Sets the designated parameter to the given <code>java.sql.SQLXML</code> object. The driver converts this to an
@@ -1992,7 +1994,7 @@ public interface CallableStatement extends PreparedStatement {
      *
      * @since 1.6
      */
-    void setSQLXML(String parameterName, SQLXML xmlObject) throws SQLException;
+    void setSQLXML(String parameterName, @Nullable SQLXML xmlObject) throws SQLException;
 
     /**
      * Retrieves the value of the designated <code>SQL XML</code> parameter as a
@@ -2006,7 +2008,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    SQLXML getSQLXML(int parameterIndex) throws SQLException;
+    @Nullable SQLXML getSQLXML(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated <code>SQL XML</code> parameter as a
@@ -2020,7 +2022,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    SQLXML getSQLXML(String parameterName) throws SQLException;
+    @Nullable SQLXML getSQLXML(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of the designated <code>NCHAR</code>,
@@ -2045,7 +2047,7 @@ public interface CallableStatement extends PreparedStatement {
      * @since 1.6
      * @see #setNString
      */
-    String getNString(int parameterIndex) throws SQLException;
+    @Nullable String getNString(int parameterIndex) throws SQLException;
 
 
     /**
@@ -2072,7 +2074,7 @@ public interface CallableStatement extends PreparedStatement {
      * @since 1.6
      * @see #setNString
      */
-    String getNString(String parameterName) throws SQLException;
+    @Nullable String getNString(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of the designated parameter as a
@@ -2092,7 +2094,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    java.io.Reader getNCharacterStream(int parameterIndex) throws SQLException;
+    java.io.@Nullable Reader getNCharacterStream(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated parameter as a
@@ -2112,7 +2114,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    java.io.Reader getNCharacterStream(String parameterName) throws SQLException;
+    java.io.@Nullable Reader getNCharacterStream(String parameterName) throws SQLException;
 
     /**
      * Retrieves the value of the designated parameter as a
@@ -2126,7 +2128,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method is called on a closed <code>CallableStatement</code>
      * @since 1.6
      */
-    java.io.Reader getCharacterStream(int parameterIndex) throws SQLException;
+    java.io.@Nullable Reader getCharacterStream(int parameterIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated parameter as a
@@ -2143,7 +2145,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    java.io.Reader getCharacterStream(String parameterName) throws SQLException;
+    java.io.@Nullable Reader getCharacterStream(String parameterName) throws SQLException;
 
     /**
      * Sets the designated parameter to the given <code>java.sql.Blob</code> object.
@@ -2159,7 +2161,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setBlob (String parameterName, Blob x) throws SQLException;
+    void setBlob (String parameterName, @Nullable Blob x) throws SQLException;
 
     /**
      * Sets the designated parameter to the given <code>java.sql.Clob</code> object.
@@ -2175,7 +2177,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setClob (String parameterName, Clob x) throws SQLException;
+    void setClob (String parameterName, @Nullable Clob x) throws SQLException;
     /**
      * Sets the designated parameter to the given input stream, which will have
      * the specified number of bytes.
@@ -2199,7 +2201,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setAsciiStream(String parameterName, java.io.InputStream x, long length)
+    void setAsciiStream(String parameterName, java.io.@Nullable InputStream x, long length)
         throws SQLException;
 
     /**
@@ -2224,7 +2226,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.6
      */
-    void setBinaryStream(String parameterName, java.io.InputStream x,
+    void setBinaryStream(String parameterName, java.io.@Nullable InputStream x,
                          long length) throws SQLException;
         /**
      * Sets the designated parameter to the given <code>Reader</code>
@@ -2251,7 +2253,7 @@ public interface CallableStatement extends PreparedStatement {
      * @since 1.6
      */
     void setCharacterStream(String parameterName,
-                            java.io.Reader reader,
+                            java.io.@Nullable Reader reader,
                             long length) throws SQLException;
      //--
     /**
@@ -2277,7 +2279,7 @@ public interface CallableStatement extends PreparedStatement {
      * @throws SQLFeatureNotSupportedException  if the JDBC driver does not support this method
        * @since 1.6
     */
-    void setAsciiStream(String parameterName, java.io.InputStream x)
+    void setAsciiStream(String parameterName, java.io.@Nullable InputStream x)
             throws SQLException;
     /**
      * Sets the designated parameter to the given input stream.
@@ -2301,7 +2303,7 @@ public interface CallableStatement extends PreparedStatement {
      * @throws SQLFeatureNotSupportedException  if the JDBC driver does not support this method
      * @since 1.6
      */
-    void setBinaryStream(String parameterName, java.io.InputStream x)
+    void setBinaryStream(String parameterName, java.io.@Nullable InputStream x)
     throws SQLException;
     /**
      * Sets the designated parameter to the given <code>Reader</code>
@@ -2329,7 +2331,7 @@ public interface CallableStatement extends PreparedStatement {
      * @since 1.6
      */
     void setCharacterStream(String parameterName,
-                          java.io.Reader reader) throws SQLException;
+                          java.io.@Nullable Reader reader) throws SQLException;
   /**
      * Sets the designated parameter to a <code>Reader</code> object. The
      * <code>Reader</code> reads the data till end-of-file is reached. The
@@ -2353,7 +2355,7 @@ public interface CallableStatement extends PreparedStatement {
      * @throws SQLFeatureNotSupportedException  if the JDBC driver does not support this method
      * @since 1.6
      */
-     void setNCharacterStream(String parameterName, Reader value) throws SQLException;
+     void setNCharacterStream(String parameterName, @Nullable Reader value) throws SQLException;
 
     /**
      * Sets the designated parameter to a <code>Reader</code> object.
@@ -2376,7 +2378,7 @@ public interface CallableStatement extends PreparedStatement {
      * @throws SQLFeatureNotSupportedException  if the JDBC driver does not support this method
      * @since 1.6
      */
-     void setClob(String parameterName, Reader reader)
+     void setClob(String parameterName, @Nullable Reader reader)
        throws SQLException;
 
     /**
@@ -2401,7 +2403,7 @@ public interface CallableStatement extends PreparedStatement {
      *
      * @since 1.6
      */
-     void setBlob(String parameterName, InputStream inputStream)
+     void setBlob(String parameterName, @Nullable InputStream inputStream)
         throws SQLException;
     /**
      * Sets the designated parameter to a <code>Reader</code> object.
@@ -2425,7 +2427,7 @@ public interface CallableStatement extends PreparedStatement {
      *
      * @since 1.6
      */
-     void setNClob(String parameterName, Reader reader)
+     void setNClob(String parameterName, @Nullable Reader reader)
        throws SQLException;
 
     //------------------------- JDBC 4.1 -----------------------------------
@@ -2457,7 +2459,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.7
      */
-     public <T> T getObject(int parameterIndex, Class<T> type) throws SQLException;
+     public <T> @Nullable T getObject(int parameterIndex, Class<T> type) throws SQLException;
 
 
     /**
@@ -2487,7 +2489,7 @@ public interface CallableStatement extends PreparedStatement {
      * this method
      * @since 1.7
      */
-     public <T> T getObject(String parameterName, Class<T> type) throws SQLException;
+     public <T> @Nullable T getObject(String parameterName, Class<T> type) throws SQLException;
 
      //------------------------- JDBC 4.2 -----------------------------------
 
@@ -2544,7 +2546,7 @@ public interface CallableStatement extends PreparedStatement {
      *
      * @since 1.8
      */
-     default void setObject(String parameterName, Object x, SQLType targetSqlType,
+     default void setObject(String parameterName, @Nullable Object x, SQLType targetSqlType,
              int scaleOrLength) throws SQLException {
         throw new SQLFeatureNotSupportedException("setObject not implemented");
     }
@@ -2569,7 +2571,7 @@ public interface CallableStatement extends PreparedStatement {
      * @see SQLType
      * @since 1.8
      */
-     default void setObject(String parameterName, Object x, SQLType targetSqlType)
+     default void setObject(String parameterName, @Nullable Object x, SQLType targetSqlType)
         throws SQLException {
         throw new SQLFeatureNotSupportedException("setObject not implemented");
     }

--- a/src/java.sql/share/classes/java/sql/PreparedStatement.java
+++ b/src/java.sql/share/classes/java/sql/PreparedStatement.java
@@ -630,7 +630,7 @@ public interface PreparedStatement extends Statement {
      * this method is called on a closed <code>PreparedStatement</code>
      * @since 1.2
      */
-    void setDate(int parameterIndex, java.sql.@Nullable Date x, Calendar cal)
+    void setDate(int parameterIndex, java.sql.@Nullable Date x, @Nullable Calendar cal)
             throws SQLException;
 
     /**
@@ -652,7 +652,7 @@ public interface PreparedStatement extends Statement {
      * this method is called on a closed <code>PreparedStatement</code>
      * @since 1.2
      */
-    void setTime(int parameterIndex, java.sql.@Nullable Time x, Calendar cal)
+    void setTime(int parameterIndex, java.sql.@Nullable Time x, @Nullable Calendar cal)
             throws SQLException;
 
     /**
@@ -674,7 +674,7 @@ public interface PreparedStatement extends Statement {
      * this method is called on a closed <code>PreparedStatement</code>
      * @since 1.2
      */
-    void setTimestamp(int parameterIndex, java.sql.@Nullable Timestamp x, Calendar cal)
+    void setTimestamp(int parameterIndex, java.sql.@Nullable Timestamp x, @Nullable Calendar cal)
             throws SQLException;
 
     /**

--- a/src/java.sql/share/classes/java/sql/ResultSet.java
+++ b/src/java.sql/share/classes/java/sql/ResultSet.java
@@ -1667,7 +1667,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException;
+    void updateBigDecimal(int columnIndex, @Nullable BigDecimal x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>String</code> value.
@@ -1686,7 +1686,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateString(int columnIndex, String x) throws SQLException;
+    void updateString(int columnIndex, @Nullable String x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>byte</code> array value.
@@ -1705,7 +1705,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateBytes(int columnIndex, byte x[]) throws SQLException;
+    void updateBytes(int columnIndex, byte x @Nullable []) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Date</code> value.
@@ -1724,7 +1724,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateDate(int columnIndex, java.sql.Date x) throws SQLException;
+    void updateDate(int columnIndex, java.sql.@Nullable Date x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Time</code> value.
@@ -1743,7 +1743,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateTime(int columnIndex, java.sql.Time x) throws SQLException;
+    void updateTime(int columnIndex, java.sql.@Nullable Time x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Timestamp</code>
@@ -1763,7 +1763,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateTimestamp(int columnIndex, java.sql.Timestamp x)
+    void updateTimestamp(int columnIndex, java.sql.@Nullable Timestamp x)
       throws SQLException;
 
     /**
@@ -1786,7 +1786,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.2
      */
     void updateAsciiStream(int columnIndex,
-                           java.io.InputStream x,
+                           java.io.@Nullable InputStream x,
                            int length) throws SQLException;
 
     /**
@@ -1809,7 +1809,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.2
      */
     void updateBinaryStream(int columnIndex,
-                            java.io.InputStream x,
+                            java.io.@Nullable InputStream x,
                             int length) throws SQLException;
 
     /**
@@ -1832,7 +1832,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.2
      */
     void updateCharacterStream(int columnIndex,
-                             java.io.Reader x,
+                             java.io.@Nullable Reader x,
                              int length) throws SQLException;
 
     /**
@@ -1865,7 +1865,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateObject(int columnIndex, Object x, int scaleOrLength)
+    void updateObject(int columnIndex, @Nullable Object x, int scaleOrLength)
       throws SQLException;
 
     /**
@@ -1886,7 +1886,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateObject(int columnIndex, Object x) throws SQLException;
+    void updateObject(int columnIndex, @Nullable Object x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>null</code> value.
@@ -2057,7 +2057,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateBigDecimal(String columnLabel, BigDecimal x) throws SQLException;
+    void updateBigDecimal(String columnLabel, @Nullable BigDecimal x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>String</code> value.
@@ -2076,7 +2076,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateString(String columnLabel, String x) throws SQLException;
+    void updateString(String columnLabel, @Nullable String x) throws SQLException;
 
     /**
      * Updates the designated column with a byte array value.
@@ -2096,7 +2096,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateBytes(String columnLabel, byte x[]) throws SQLException;
+    void updateBytes(String columnLabel, byte @Nullable [] x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Date</code> value.
@@ -2115,7 +2115,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateDate(String columnLabel, java.sql.Date x) throws SQLException;
+    void updateDate(String columnLabel, java.sql.@Nullable Date x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Time</code> value.
@@ -2134,7 +2134,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateTime(String columnLabel, java.sql.Time x) throws SQLException;
+    void updateTime(String columnLabel, java.sql.@Nullable Time x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Timestamp</code>
@@ -2154,7 +2154,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateTimestamp(String columnLabel, java.sql.Timestamp x)
+    void updateTimestamp(String columnLabel, java.sql.@Nullable Timestamp x)
       throws SQLException;
 
     /**
@@ -2177,7 +2177,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.2
      */
     void updateAsciiStream(String columnLabel,
-                           java.io.InputStream x,
+                           java.io.@Nullable InputStream x,
                            int length) throws SQLException;
 
     /**
@@ -2200,7 +2200,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.2
      */
     void updateBinaryStream(String columnLabel,
-                            java.io.InputStream x,
+                            java.io.@Nullable InputStream x,
                             int length) throws SQLException;
 
     /**
@@ -2224,7 +2224,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.2
      */
     void updateCharacterStream(String columnLabel,
-                             java.io.Reader reader,
+                             java.io.@Nullable Reader reader,
                              int length) throws SQLException;
 
     /**
@@ -2257,7 +2257,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateObject(String columnLabel, Object x, int scaleOrLength)
+    void updateObject(String columnLabel, @Nullable Object x, int scaleOrLength)
       throws SQLException;
 
     /**
@@ -2278,7 +2278,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    void updateObject(String columnLabel, Object x) throws SQLException;
+    void updateObject(String columnLabel, @Nullable Object x) throws SQLException;
 
     /**
      * Inserts the contents of the insert row into this
@@ -2476,7 +2476,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Ref getRef(int columnIndex) throws SQLException;
+    @Nullable Ref getRef(int columnIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2510,7 +2510,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Clob getClob(int columnIndex) throws SQLException;
+    @Nullable Clob getClob(int columnIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2527,7 +2527,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Array getArray(int columnIndex) throws SQLException;
+    @Nullable Array getArray(int columnIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2550,7 +2550,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Object getObject(String columnLabel, java.util.Map<String,Class<?>> map)
+    @Nullable Object getObject(String columnLabel, java.util.Map<String,Class<?>> map)
       throws SQLException;
 
     /**
@@ -2568,7 +2568,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Ref getRef(String columnLabel) throws SQLException;
+    @Nullable Ref getRef(String columnLabel) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2585,7 +2585,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Blob getBlob(String columnLabel) throws SQLException;
+    @Nullable Blob getBlob(String columnLabel) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2602,7 +2602,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Clob getClob(String columnLabel) throws SQLException;
+    @Nullable Clob getClob(String columnLabel) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2619,7 +2619,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.2
      */
-    Array getArray(String columnLabel) throws SQLException;
+    @Nullable Array getArray(String columnLabel) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2640,7 +2640,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * or this method is called on a closed result set
      * @since 1.2
      */
-    java.sql.@Nullable Date getDate(int columnIndex, Calendar cal) throws SQLException;
+    java.sql.@Nullable Date getDate(int columnIndex, @Nullable Calendar cal) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2661,7 +2661,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * or this method is called on a closed result set
      * @since 1.2
      */
-    java.sql.@Nullable Date getDate(String columnLabel, Calendar cal) throws SQLException;
+    java.sql.@Nullable Date getDate(String columnLabel, @Nullable Calendar cal) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2682,7 +2682,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * or this method is called on a closed result set
      * @since 1.2
      */
-    java.sql.@Nullable Time getTime(int columnIndex, Calendar cal) throws SQLException;
+    java.sql.@Nullable Time getTime(int columnIndex, @Nullable Calendar cal) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2703,7 +2703,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * or this method is called on a closed result set
      * @since 1.2
      */
-    java.sql.@Nullable Time getTime(String columnLabel, Calendar cal) throws SQLException;
+    java.sql.@Nullable Time getTime(String columnLabel, @Nullable Calendar cal) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -2724,7 +2724,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * or this method is called on a closed result set
      * @since 1.2
      */
-    java.sql.@Nullable Timestamp getTimestamp(int columnIndex, Calendar cal)
+    java.sql.@Nullable Timestamp getTimestamp(int columnIndex, @Nullable Calendar cal)
       throws SQLException;
 
     /**
@@ -2746,7 +2746,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * or this method is called on a closed result set
      * @since 1.2
      */
-    java.sql.@Nullable Timestamp getTimestamp(String columnLabel, Calendar cal)
+    java.sql.@Nullable Timestamp getTimestamp(String columnLabel, @Nullable Calendar cal)
       throws SQLException;
 
     //-------------------------- JDBC 3.0 ----------------------------------------
@@ -2820,7 +2820,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateRef(int columnIndex, java.sql.Ref x) throws SQLException;
+    void updateRef(int columnIndex, java.sql.@Nullable Ref x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Ref</code> value.
@@ -2839,7 +2839,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateRef(String columnLabel, java.sql.Ref x) throws SQLException;
+    void updateRef(String columnLabel, java.sql.@Nullable Ref x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Blob</code> value.
@@ -2858,7 +2858,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateBlob(int columnIndex, java.sql.Blob x) throws SQLException;
+    void updateBlob(int columnIndex, java.sql.@Nullable Blob x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Blob</code> value.
@@ -2877,7 +2877,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateBlob(String columnLabel, java.sql.Blob x) throws SQLException;
+    void updateBlob(String columnLabel, java.sql.@Nullable Blob x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Clob</code> value.
@@ -2896,7 +2896,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateClob(int columnIndex, java.sql.Clob x) throws SQLException;
+    void updateClob(int columnIndex, java.sql.@Nullable Clob x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Clob</code> value.
@@ -2915,7 +2915,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateClob(String columnLabel, java.sql.Clob x) throws SQLException;
+    void updateClob(String columnLabel, java.sql.@Nullable Clob x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Array</code> value.
@@ -2934,7 +2934,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateArray(int columnIndex, java.sql.Array x) throws SQLException;
+    void updateArray(int columnIndex, java.sql.@Nullable Array x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.Array</code> value.
@@ -2953,7 +2953,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.4
      */
-    void updateArray(String columnLabel, java.sql.Array x) throws SQLException;
+    void updateArray(String columnLabel, java.sql.@Nullable Array x) throws SQLException;
 
     //------------------------- JDBC 4.0 -----------------------------------
 
@@ -3008,7 +3008,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateRowId(int columnIndex, RowId x) throws SQLException;
+    void updateRowId(int columnIndex, @Nullable RowId x) throws SQLException;
 
     /**
      * Updates the designated column with a <code>RowId</code> value. The updater
@@ -3027,7 +3027,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateRowId(String columnLabel, RowId x) throws SQLException;
+    void updateRowId(String columnLabel, @Nullable RowId x) throws SQLException;
 
     /**
      * Retrieves the holdability of this <code>ResultSet</code> object
@@ -3069,7 +3069,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNString(int columnIndex, String nString) throws SQLException;
+    void updateNString(int columnIndex, @Nullable String nString) throws SQLException;
 
     /**
      * Updates the designated column with a <code>String</code> value.
@@ -3092,7 +3092,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNString(String columnLabel, String nString) throws SQLException;
+    void updateNString(String columnLabel, @Nullable String nString) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.NClob</code> value.
@@ -3113,7 +3113,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNClob(int columnIndex, NClob nClob) throws SQLException;
+    void updateNClob(int columnIndex, @Nullable NClob nClob) throws SQLException;
 
     /**
      * Updates the designated column with a <code>java.sql.NClob</code> value.
@@ -3134,7 +3134,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNClob(String columnLabel, NClob nClob) throws SQLException;
+    void updateNClob(String columnLabel, @Nullable NClob nClob) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -3153,7 +3153,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    NClob getNClob(int columnIndex) throws SQLException;
+    @Nullable NClob getNClob(int columnIndex) throws SQLException;
 
   /**
      * Retrieves the value of the designated column in the current row
@@ -3172,7 +3172,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    NClob getNClob(String columnLabel) throws SQLException;
+    @Nullable NClob getNClob(String columnLabel) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in  the current row of
@@ -3187,7 +3187,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    SQLXML getSQLXML(int columnIndex) throws SQLException;
+    @Nullable SQLXML getSQLXML(int columnIndex) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in  the current row of
@@ -3202,7 +3202,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    SQLXML getSQLXML(String columnLabel) throws SQLException;
+    @Nullable SQLXML getSQLXML(String columnLabel) throws SQLException;
     /**
      * Updates the designated column with a <code>java.sql.SQLXML</code> value.
      * The updater
@@ -3227,7 +3227,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateSQLXML(int columnIndex, SQLXML xmlObject) throws SQLException;
+    void updateSQLXML(int columnIndex, @Nullable SQLXML xmlObject) throws SQLException;
     /**
      * Updates the designated column with a <code>java.sql.SQLXML</code> value.
      * The updater
@@ -3252,7 +3252,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateSQLXML(String columnLabel, SQLXML xmlObject) throws SQLException;
+    void updateSQLXML(String columnLabel, @Nullable SQLXML xmlObject) throws SQLException;
 
     /**
      * Retrieves the value of the designated column in the current row
@@ -3363,7 +3363,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateNCharacterStream(int columnIndex,
-                             java.io.Reader x,
+                             java.io.@Nullable Reader x,
                              long length) throws SQLException;
 
     /**
@@ -3392,7 +3392,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateNCharacterStream(String columnLabel,
-                             java.io.Reader reader,
+                             java.io.@Nullable Reader reader,
                              long length) throws SQLException;
     /**
      * Updates the designated column with an ascii stream value, which will have
@@ -3415,7 +3415,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateAsciiStream(int columnIndex,
-                           java.io.InputStream x,
+                           java.io.@Nullable InputStream x,
                            long length) throws SQLException;
 
     /**
@@ -3439,7 +3439,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateBinaryStream(int columnIndex,
-                            java.io.InputStream x,
+                            java.io.@Nullable InputStream x,
                             long length) throws SQLException;
 
     /**
@@ -3463,7 +3463,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateCharacterStream(int columnIndex,
-                             java.io.Reader x,
+                             java.io.@Nullable Reader x,
                              long length) throws SQLException;
     /**
      * Updates the designated column with an ascii stream value, which will have
@@ -3486,7 +3486,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateAsciiStream(String columnLabel,
-                           java.io.InputStream x,
+                           java.io.@Nullable InputStream x,
                            long length) throws SQLException;
 
     /**
@@ -3510,7 +3510,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateBinaryStream(String columnLabel,
-                            java.io.InputStream x,
+                            java.io.@Nullable InputStream x,
                             long length) throws SQLException;
 
     /**
@@ -3535,7 +3535,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateCharacterStream(String columnLabel,
-                             java.io.Reader reader,
+                             java.io.@Nullable Reader reader,
                              long length) throws SQLException;
     /**
      * Updates the designated column using the given input stream, which
@@ -3559,7 +3559,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateBlob(int columnIndex, InputStream inputStream, long length) throws SQLException;
+    void updateBlob(int columnIndex, @Nullable InputStream inputStream, long length) throws SQLException;
 
     /**
      * Updates the designated column using the given input stream, which
@@ -3583,7 +3583,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateBlob(String columnLabel, InputStream inputStream, long length) throws SQLException;
+    void updateBlob(String columnLabel, @Nullable InputStream inputStream, long length) throws SQLException;
 
     /**
      * Updates the designated column using the given <code>Reader</code>
@@ -3610,7 +3610,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateClob(int columnIndex,  Reader reader, long length) throws SQLException;
+    void updateClob(int columnIndex,  @Nullable Reader reader, long length) throws SQLException;
 
     /**
      * Updates the designated column using the given <code>Reader</code>
@@ -3637,7 +3637,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateClob(String columnLabel,  Reader reader, long length) throws SQLException;
+    void updateClob(String columnLabel,  @Nullable Reader reader, long length) throws SQLException;
    /**
      * Updates the designated column using the given <code>Reader</code>
      * object, which is the given number of characters long.
@@ -3665,7 +3665,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNClob(int columnIndex,  Reader reader, long length) throws SQLException;
+    void updateNClob(int columnIndex,  @Nullable Reader reader, long length) throws SQLException;
 
     /**
      * Updates the designated column using the given <code>Reader</code>
@@ -3694,7 +3694,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNClob(String columnLabel,  Reader reader, long length) throws SQLException;
+    void updateNClob(String columnLabel,  @Nullable Reader reader, long length) throws SQLException;
 
     //---
 
@@ -3727,7 +3727,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateNCharacterStream(int columnIndex,
-                             java.io.Reader x) throws SQLException;
+                             java.io.@Nullable Reader x) throws SQLException;
 
     /**
      * Updates the designated column with a character stream value.
@@ -3759,7 +3759,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateNCharacterStream(String columnLabel,
-                             java.io.Reader reader) throws SQLException;
+                             java.io.@Nullable Reader reader) throws SQLException;
     /**
      * Updates the designated column with an ascii stream value.
      * The data will be read from the stream
@@ -3812,7 +3812,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateBinaryStream(int columnIndex,
-                            java.io.InputStream x) throws SQLException;
+                            java.io.@Nullable InputStream x) throws SQLException;
 
     /**
      * Updates the designated column with a character stream value.
@@ -3865,7 +3865,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateAsciiStream(String columnLabel,
-                           java.io.InputStream x) throws SQLException;
+                           java.io.@Nullable InputStream x) throws SQLException;
 
     /**
      * Updates the designated column with a binary stream value.
@@ -3892,7 +3892,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateBinaryStream(String columnLabel,
-                            java.io.InputStream x) throws SQLException;
+                            java.io.@Nullable InputStream x) throws SQLException;
 
     /**
      * Updates the designated column with a character stream value.
@@ -3919,7 +3919,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @since 1.6
      */
     void updateCharacterStream(String columnLabel,
-                             java.io.Reader reader) throws SQLException;
+                             java.io.@Nullable Reader reader) throws SQLException;
     /**
      * Updates the designated column using the given input stream. The data will be read from the stream
      * as needed until end-of-stream is reached.
@@ -3943,7 +3943,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateBlob(int columnIndex, InputStream inputStream) throws SQLException;
+    void updateBlob(int columnIndex, @Nullable InputStream inputStream) throws SQLException;
 
     /**
      * Updates the designated column using the given input stream. The data will be read from the stream
@@ -3968,7 +3968,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateBlob(String columnLabel, InputStream inputStream) throws SQLException;
+    void updateBlob(String columnLabel, @Nullable InputStream inputStream) throws SQLException;
 
     /**
      * Updates the designated column using the given <code>Reader</code>
@@ -3997,7 +3997,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateClob(int columnIndex,  Reader reader) throws SQLException;
+    void updateClob(int columnIndex,  @Nullable Reader reader) throws SQLException;
 
     /**
      * Updates the designated column using the given <code>Reader</code>
@@ -4025,7 +4025,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateClob(String columnLabel,  Reader reader) throws SQLException;
+    void updateClob(String columnLabel,  @Nullable Reader reader) throws SQLException;
    /**
      * Updates the designated column using the given <code>Reader</code>
      *
@@ -4055,7 +4055,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNClob(int columnIndex,  Reader reader) throws SQLException;
+    void updateNClob(int columnIndex,  @Nullable Reader reader) throws SQLException;
 
     /**
      * Updates the designated column using the given <code>Reader</code>
@@ -4085,7 +4085,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.6
      */
-    void updateNClob(String columnLabel,  Reader reader) throws SQLException;
+    void updateNClob(String columnLabel,  @Nullable Reader reader) throws SQLException;
 
     //------------------------- JDBC 4.1 -----------------------------------
 
@@ -4115,7 +4115,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.7
      */
-     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException;
+     public <T> @Nullable T getObject(int columnIndex, Class<T> type) throws SQLException;
 
 
     /**
@@ -4146,7 +4146,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * this method
      * @since 1.7
      */
-     public <T> T getObject(String columnLabel, Class<T> type) throws SQLException;
+     public <T> @Nullable T getObject(String columnLabel, Class<T> type) throws SQLException;
 
     //------------------------- JDBC 4.2 -----------------------------------
 
@@ -4185,7 +4185,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @see SQLType
      * @since 1.8
      */
-     default void updateObject(int columnIndex, Object x,
+     default void updateObject(int columnIndex, @Nullable Object x,
              SQLType targetSqlType, int scaleOrLength)  throws SQLException {
         throw new SQLFeatureNotSupportedException("updateObject not implemented");
     }
@@ -4228,7 +4228,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @see SQLType
      * @since 1.8
      */
-    default void updateObject(String columnLabel, Object x,
+    default void updateObject(String columnLabel, @Nullable Object x,
             SQLType targetSqlType, int scaleOrLength) throws SQLException {
         throw new SQLFeatureNotSupportedException("updateObject not implemented");
     }
@@ -4256,7 +4256,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @see SQLType
      * @since 1.8
      */
-    default void updateObject(int columnIndex, Object x, SQLType targetSqlType)
+    default void updateObject(int columnIndex, @Nullable Object x, SQLType targetSqlType)
             throws SQLException {
         throw new SQLFeatureNotSupportedException("updateObject not implemented");
     }
@@ -4286,7 +4286,7 @@ public interface ResultSet extends Wrapper, AutoCloseable {
      * @see SQLType
      * @since 1.8
      */
-    default void updateObject(String columnLabel, Object x,
+    default void updateObject(String columnLabel, @Nullable Object x,
             SQLType targetSqlType) throws SQLException {
         throw new SQLFeatureNotSupportedException("updateObject not implemented");
     }


### PR DESCRIPTION
Most `get...` are allowed to return `null` (e.g. `getString`), so I added `@Nullable` for other getters like `getRowid()`.

There are two less trivial changes:

a) 
```java
public <T> @Nullable T getObject(int parameterIndex, Class<T> type) throws SQLException;
```

I'm not sure if it should be written as `public <@Nullable T> T ...`.

b) `(...Calendar cal)`. It is not clear if the spec allows `null` calendar, however, AFAIK the implementations allow nulls, and there's an obscure Javadoc which suggests that `calendar can be missing`.
The only way I can imagine a "missing" calendar is a `null` reference.

```java
    /**
     * Sets the designated parameter to the given <code>java.sql.Date</code> value,
     * using the given <code>Calendar</code> object.  The driver uses
     * the <code>Calendar</code> object to construct an SQL <code>DATE</code> value,
     * which the driver then sends to the database.  With
     * a <code>Calendar</code> object, the driver can calculate the date
     * taking into account a custom timezone.  If no
     * <code>Calendar</code> object is specified, the driver uses the default
     * timezone, which is that of the virtual machine running the application.
     *
     * @param parameterIndex the first parameter is 1, the second is 2, ...
     * @param x the parameter value
     * @param cal the <code>Calendar</code> object the driver will use
     *            to construct the date
     * @exception SQLException if parameterIndex does not correspond to a parameter
     * marker in the SQL statement; if a database access error occurs or
     * this method is called on a closed <code>PreparedStatement</code>
     * @since 1.2
     */
    void setDate(int parameterIndex, java.sql.@Nullable Date x, @Nullable Calendar cal)
            throws SQLException;
```
