### PR TITLE
Standardize on `@AnnotatedFor({"nullness"})`.

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassCircularityError.java
+++ b/src/java.base/share/classes/java/lang/ClassCircularityError.java
@@ -36,7 +36,7 @@ import org.checkerframework.framework.qual.AnnotatedFor;
  * @author     unascribed
  * @since      1.0
  */
-@AnnotatedFor({"nullnesss"})
+@AnnotatedFor({"nullness"})
 public class ClassCircularityError extends LinkageError {
     private static final long serialVersionUID = 1054362542914539689L;
 

--- a/src/java.base/share/classes/java/lang/InstantiationError.java
+++ b/src/java.base/share/classes/java/lang/InstantiationError.java
@@ -42,7 +42,7 @@ import org.checkerframework.framework.qual.AnnotatedFor;
  */
 
 
-@AnnotatedFor({"nullable"})
+@AnnotatedFor({"nullness"})
 public
 class InstantiationError extends IncompatibleClassChangeError {
     private static final long serialVersionUID = -4885810657349421204L;

--- a/src/java.base/share/classes/java/lang/RuntimePermission.java
+++ b/src/java.base/share/classes/java/lang/RuntimePermission.java
@@ -401,7 +401,7 @@ import java.lang.module.ModuleFinder;
  * @since 1.2
  */
 
-@AnnotatedFor({"nullnes"})
+@AnnotatedFor({"nullness"})
 public final class RuntimePermission extends BasicPermission {
 
     private static final long serialVersionUID = 7399184964622342223L;

--- a/src/java.base/share/classes/java/lang/ThreadGroup.java
+++ b/src/java.base/share/classes/java/lang/ThreadGroup.java
@@ -63,7 +63,7 @@ import jdk.internal.misc.VM;
  * and working off of that snapshot, rather than holding the thread group locked
  * while we work on the children.
  */
-@AnnotatedFor({"index", "interning", "lock", "nullable"})
+@AnnotatedFor({"index", "interning", "lock", "nullness"})
 public
 @UsesObjectEquals class ThreadGroup implements Thread.UncaughtExceptionHandler {
     private final ThreadGroup parent;

--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -119,7 +119,7 @@ import  java.util.*;
  * @jls 11.2 Compile-Time Checking of Exceptions
  * @since 1.0
  */
-@AnnotatedFor({"interning", "lock", "nullable"})
+@AnnotatedFor({"interning", "lock", "nullness"})
 public @UsesObjectEquals class Throwable implements Serializable {
     /** use serialVersionUID from JDK 1.0.2 for interoperability */
     private static final long serialVersionUID = -3042686055658047285L;


### PR DESCRIPTION
Some files currently use slightly different forms of this.