### PR TITLE
Annotated AnnotatedElement and its implementations.

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -3742,7 +3742,7 @@ public final @Interned class Class<@UnknownKeyFor T> implements java.io.Serializ
      */
     @Override
     @SuppressWarnings("unchecked")
-    public <A extends Annotation> A getDeclaredAnnotation(Class<A> annotationClass) {
+    public <A extends Annotation> @Nullable A getDeclaredAnnotation(Class<A> annotationClass) {
         Objects.requireNonNull(annotationClass);
 
         return (A) annotationData().declaredAnnotations.get(annotationClass);

--- a/src/java.base/share/classes/java/lang/Package.java
+++ b/src/java.base/share/classes/java/lang/Package.java
@@ -489,7 +489,7 @@ public @UsesObjectEquals class Package extends NamedPackage implements java.lang
      * @since 1.8
      */
     @Override
-    public <A extends Annotation> A getDeclaredAnnotation(Class<A> annotationClass) {
+    public <A extends Annotation> @Nullable A getDeclaredAnnotation(Class<A> annotationClass) {
         return getPackageInfo().getDeclaredAnnotation(annotationClass);
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
+++ b/src/java.base/share/classes/java/lang/reflect/AccessibleObject.java
@@ -25,6 +25,10 @@
 
 package java.lang.reflect;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.framework.qual.CFComment;
+
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandle;
 import java.security.AccessController;
@@ -72,6 +76,7 @@ import sun.security.util.SecurityConstants;
  * @revised 9
  * @spec JPMS
  */
+@AnnotatedFor({"nullness"})
 public class AccessibleObject implements AnnotatedElement {
 
     static void checkPermission() {
@@ -444,6 +449,7 @@ public class AccessibleObject implements AnnotatedElement {
      * @see #setAccessible(boolean)
      */
     @CallerSensitive
+    @CFComment("Sometimes null is forbidden; other times, it is required")
     public final boolean canAccess(Object obj) {
         if (!Member.class.isInstance(this)) {
             return override;
@@ -503,7 +509,7 @@ public class AccessibleObject implements AnnotatedElement {
      * @throws NullPointerException {@inheritDoc}
      * @since 1.5
      */
-    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
         throw new AssertionError("All subclasses should override this method");
     }
 
@@ -538,7 +544,7 @@ public class AccessibleObject implements AnnotatedElement {
      * @since 1.8
      */
     @Override
-    public <T extends Annotation> T getDeclaredAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getDeclaredAnnotation(Class<T> annotationClass) {
         // Only annotations on classes are inherited, for all other
         // objects getDeclaredAnnotation is the same as
         // getAnnotation.

--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
@@ -293,7 +293,7 @@ public interface AnnotatedElement {
      * @throws NullPointerException if the given annotation class is null
      * @since 1.5
      */
-    <T extends @Nullable Annotation> @Nullable T getAnnotation(Class<T> annotationClass);
+    <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass);
 
     /**
      * Returns annotations that are <em>present</em> on this element.

--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -590,7 +590,7 @@ public final class Constructor<T> extends Executable {
      * @throws NullPointerException  {@inheritDoc}
      * @since 1.5
      */
-    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
         return super.getAnnotation(annotationClass);
     }
 
@@ -644,7 +644,7 @@ public final class Constructor<T> extends Executable {
      * @since 1.8
      */
     @Override
-    public AnnotatedType getAnnotatedReceiverType() {
+    public @Nullable AnnotatedType getAnnotatedReceiverType() {
         Class<?> thisDeclClass = getDeclaringClass();
         Class<?> enclosingClass = thisDeclClass.getEnclosingClass();
 

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -25,6 +25,7 @@
 
 package java.lang.reflect;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.lang.annotation.*;

--- a/src/java.base/share/classes/java/lang/reflect/Executable.java
+++ b/src/java.base/share/classes/java/lang/reflect/Executable.java
@@ -25,6 +25,8 @@
 
 package java.lang.reflect;
 
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.lang.annotation.*;
 import java.util.Map;
 import java.util.Objects;
@@ -43,6 +45,7 @@ import sun.reflect.generics.repository.ConstructorRepository;
  *
  * @since 1.8
  */
+@AnnotatedFor({"nullness"})
 public abstract class Executable extends AccessibleObject
     implements Member, GenericDeclaration {
     /*
@@ -567,7 +570,7 @@ public abstract class Executable extends AccessibleObject
      * {@inheritDoc}
      * @throws NullPointerException  {@inheritDoc}
      */
-    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
         Objects.requireNonNull(annotationClass);
         return annotationClass.cast(declaredAnnotations().get(annotationClass));
     }
@@ -670,7 +673,7 @@ public abstract class Executable extends AccessibleObject
      * constructor represented by this {@code Executable} or {@code null} if
      * this {@code Executable} can not have a receiver parameter
      */
-    public AnnotatedType getAnnotatedReceiverType() {
+    public @Nullable AnnotatedType getAnnotatedReceiverType() {
         if (Modifier.isStatic(this.getModifiers()))
             return null;
         return TypeAnnotationParser.buildAnnotatedType(getTypeAnnotationBytes0(),

--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -1177,7 +1177,7 @@ class Field extends AccessibleObject implements Member {
      * @since 1.5
      */
     @SideEffectFree
-    public <T extends @Nullable Annotation> @Nullable T getAnnotation(@GuardSatisfied Field this, Class<@NonNull T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(@GuardSatisfied Field this, Class<T> annotationClass) {
         Objects.requireNonNull(annotationClass);
         return annotationClass.cast(declaredAnnotations().get(annotationClass));
     }

--- a/src/java.base/share/classes/java/lang/reflect/GenericDeclaration.java
+++ b/src/java.base/share/classes/java/lang/reflect/GenericDeclaration.java
@@ -25,11 +25,14 @@
 
 package java.lang.reflect;
 
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A common interface for all entities that declare type variables.
  *
  * @since 1.5
  */
+@AnnotatedFor({"nullness"})
 public interface GenericDeclaration extends AnnotatedElement {
     /**
      * Returns an array of {@code TypeVariable} objects that

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -714,7 +714,7 @@ public final class Method extends Executable {
      * @throws NullPointerException  {@inheritDoc}
      * @since 1.5
      */
-    public <T extends @Nullable Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
         return super.getAnnotation(annotationClass);
     }
 

--- a/src/java.base/share/classes/java/lang/reflect/Parameter.java
+++ b/src/java.base/share/classes/java/lang/reflect/Parameter.java
@@ -29,6 +29,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
+import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.lang.annotation.*;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import sun.reflect.annotation.AnnotationSupport;
  *
  * @since 1.8
  */
+@AnnotatedFor({"nullness"})
 public final class Parameter implements AnnotatedElement {
 
     private final String name;
@@ -290,7 +292,7 @@ public final class Parameter implements AnnotatedElement {
      * {@inheritDoc}
      * @throws NullPointerException {@inheritDoc}
      */
-    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getAnnotation(Class<T> annotationClass) {
         Objects.requireNonNull(annotationClass);
         return annotationClass.cast(declaredAnnotations().get(annotationClass));
     }
@@ -316,7 +318,7 @@ public final class Parameter implements AnnotatedElement {
     /**
      * @throws NullPointerException {@inheritDoc}
      */
-    public <T extends Annotation> T getDeclaredAnnotation(Class<T> annotationClass) {
+    public <T extends Annotation> @Nullable T getDeclaredAnnotation(Class<T> annotationClass) {
         // Only annotations on classes are inherited, for all other
         // objects getDeclaredAnnotation is the same as
         // getAnnotation.


### PR DESCRIPTION
This includes standardizing the bound of `getAnnotation` as `<T extends Annotation>`, rather than `<T extends @Nullable Annotation>`. The latter is currently less common (especially if you count instances of `Class<? extends Annotation`), and it feels more broad than necessary.