### PR TITLE
add @Pure to getLength of Array

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Array.java
+++ b/src/java.base/share/classes/java/lang/reflect/Array.java
@@ -29,8 +29,8 @@ import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.framework.qual.AnnotatedFor;
-import org.checkerframework.framework.util.PurityChecker.qual.Pure;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
 

--- a/src/java.base/share/classes/java/lang/reflect/Array.java
+++ b/src/java.base/share/classes/java/lang/reflect/Array.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.framework.util.PurityChecker.qual.Pure;
 
 import jdk.internal.HotSpotIntrinsicCandidate;
 
@@ -130,7 +131,7 @@ public final
      * an array
      */
     @HotSpotIntrinsicCandidate
-    public static native @LengthOf({"#1"}) int getLength(Object array)
+    public static native @Pure @LengthOf({"#1"}) int getLength(Object array)
         throws IllegalArgumentException;
 
     /**


### PR DESCRIPTION
Array.getLength method has no visible side effects and is deterministic, therefore should be annotated as @Pure.