### PR TITLE
Allow "source" to be not initialized

### DIFF
--- a/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyChangeSupport.java
@@ -29,6 +29,8 @@ import org.checkerframework.checker.guieffect.qual.PolyUI;
 import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
 import org.checkerframework.checker.guieffect.qual.PolyUIType;
 import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
@@ -99,7 +101,7 @@ public @UsesObjectEquals class PropertyChangeSupport implements Serializable {
      * @param sourceBean  The bean to be given as the source for any events.
      */
     @SafeEffect
-    public PropertyChangeSupport(@PolyUI Object sourceBean) {
+    public PropertyChangeSupport(@PolyUI @UnknownInitialization(Object.class) Object sourceBean) {
         if (sourceBean == null) {
             throw new NullPointerException();
         }
@@ -506,7 +508,7 @@ public @UsesObjectEquals class PropertyChangeSupport implements Serializable {
     /**
      * The object to be provided as the "source" for any generated events.
      */
-    private Object source;
+    private @NotOnlyInitialized Object source;
 
     /**
      * @serialField children                                   Hashtable


### PR DESCRIPTION
The source property on PropertyChangeSupport needs to be able to store uninitialized values. This is OK since the source property isn't used until after construction of all objects is complete.