### PR TITLE
Add annotations to "new" `LinkageError` constructor.

### DIFF
--- a/src/java.base/share/classes/java/lang/LinkageError.java
+++ b/src/java.base/share/classes/java/lang/LinkageError.java
@@ -70,7 +70,8 @@ class LinkageError extends Error {
      * @param cause the cause, may be {@code null}
      * @since 1.7
      */
-    public LinkageError(String s, Throwable cause) {
+    @SideEffectFree
+    public LinkageError(@Nullable String s, @Nullable Throwable cause) {
         super(s, cause);
     }
 }


### PR DESCRIPTION
A quick grep through `java.base` suggests that all other
`*Exception.java` and `*Error.java` classes that are
`@AnnotatedFor("nullness")` already have `@Nullable` on their
constructor parameters.

(A sort of exception: `PatternSyntaxException`. However, that has
special fields of its own, not just `message` and `cause`.)