### PR TITLE
j.u.Optional: Ensure @Present for more methods

### DIFF
--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -483,6 +483,7 @@ public final @NonNull class Optional<T> {
      * @return hash code value of the present value or {@code 0} if no value is
      *         present
      */
+    @Pure
     @Override
     public int hashCode() {
         return Objects.hashCode(value);

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -407,7 +407,7 @@ public final @NonNull class Optional<T> {
      * @since 10
      */
     @EnsuresQualifier(expression = "this", qualifier = Present.class)
-    public T orElseThrow() {
+    public T orElseThrow(@Present Optional<T> this) {
         if (value == null) {
             throw new NoSuchElementException("No value present");
         }

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -34,6 +34,7 @@ import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.qual.CFComment;
 import org.checkerframework.framework.qual.Covariant;
+import org.checkerframework.framework.qual.EnsuresQualifier;
 import org.checkerframework.framework.qual.EnsuresQualifierIf;
 
 import java.util.function.Consumer;
@@ -193,6 +194,7 @@ public final @NonNull class Optional<T> {
      * @since   11
      */
     @Pure
+    @EnsuresQualifierIf(result = false, expression = "this", qualifier = Present.class)
     public boolean isEmpty() {
         return value == null;
     }
@@ -404,6 +406,7 @@ public final @NonNull class Optional<T> {
      * @throws NoSuchElementException if no value is present
      * @since 10
      */
+    @EnsuresQualifier(expression = "this", qualifier = Present.class)
     public T orElseThrow() {
         if (value == null) {
             throw new NoSuchElementException("No value present");
@@ -428,6 +431,7 @@ public final @NonNull class Optional<T> {
      * @throws NullPointerException if no value is present and the exception
      *          supplying function is {@code null}
      */
+    @EnsuresQualifier(expression = "this", qualifier = Present.class)
     public <X extends Throwable> T orElseThrow(@Present Optional<T> this, Supplier<? extends X> exceptionSupplier) throws X {
         if (value != null) {
             return value;

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -369,6 +369,7 @@ public final @NonNull class Optional<T> {
      * @return the optional value as a {@code Stream}
      * @since 9
      */
+    @SideEffectFree
     public Stream<T> stream() {
         if (!isPresent()) {
             return Stream.empty();

--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -117,6 +117,7 @@ public final @NonNull class Optional<T> {
      * @param <T> The type of the non-existent value
      * @return an empty {@code Optional}
      */
+    @SideEffectFree
     public static<T> Optional<T> empty() {
         @SuppressWarnings("unchecked")
         Optional<T> t = (Optional<T>) EMPTY;
@@ -142,6 +143,7 @@ public final @NonNull class Optional<T> {
      * @return an {@code Optional} with the value present
      * @throws NullPointerException if value is {@code null}
      */
+    @SideEffectFree
     public static <T> @Present Optional<T> of(@NonNull T value) {
         return new Optional<>(value);
     }
@@ -155,6 +157,7 @@ public final @NonNull class Optional<T> {
      * @return an {@code Optional} with a present value if the specified value
      *         is non-{@code null}, otherwise an empty {@code Optional}
      */
+    @SideEffectFree
     public static <T> Optional<T> ofNullable(@Nullable T value) {
         return value == null ? empty() : of(value);
     }
@@ -169,6 +172,7 @@ public final @NonNull class Optional<T> {
      * @return the non-{@code null} value described by this {@code Optional}
      * @throws NoSuchElementException if no value is present
      */
+    @Pure
     public @NonNull T get(@Present Optional<T> this) {
         if (value == null) {
             throw new NoSuchElementException("No value present");
@@ -181,6 +185,7 @@ public final @NonNull class Optional<T> {
      *
      * @return {@code true} if a value is present, otherwise {@code false}
      */
+    @Pure
     @EnsuresQualifierIf(result = true, expression = "this", qualifier = Present.class)
     public boolean isPresent() {
         return value != null;
@@ -380,6 +385,7 @@ public final @NonNull class Optional<T> {
      *        May be {@code null}.
      * @return the value, if present, otherwise {@code other}
      */
+    @Pure
     public @PolyNull T orElse(@PolyNull T other) {
         return value != null ? value : other;
     }
@@ -406,6 +412,7 @@ public final @NonNull class Optional<T> {
      * @throws NoSuchElementException if no value is present
      * @since 10
      */
+    @Pure
     @EnsuresQualifier(expression = "this", qualifier = Present.class)
     public T orElseThrow(@Present Optional<T> this) {
         if (value == null) {
@@ -493,6 +500,7 @@ public final @NonNull class Optional<T> {
      *
      * @return the string representation of this instance
      */
+    @SideEffectFree
     @Override
     public String toString() {
         return value != null


### PR DESCRIPTION
Merge with https://github.com/typetools/checker-framework/issues/4005

I think all methods on `Optional` should also be `@Pure`, wdyt?