### PR TITLE
Have initCause() return an @Initialized throwable

### DIFF
--- a/src/java.base/share/classes/java/lang/Throwable.java
+++ b/src/java.base/share/classes/java/lang/Throwable.java
@@ -472,7 +472,7 @@ public @UsesObjectEquals class Throwable implements Serializable {
      *         been called on this throwable.
      * @since  1.4
      */
-    public synchronized @UnknownInitialization Throwable initCause(@UnknownInitialization Throwable this, @Nullable Throwable cause) {
+    public synchronized Throwable initCause(@UnknownInitialization Throwable this, @Nullable Throwable cause) {
         if (this.cause != this)
             throw new IllegalStateException("Can't overwrite cause with " +
                                             Objects.toString(cause, "a null"), this);


### PR DESCRIPTION
The current behavior of returning an @UnknownInitialization throwable prevents common method chaining like: "new Throwable(e.getMessage().initCause(e)", as the initialization checker complains the result is not @Initialized. This exact pattern is suggested in the javadocs for this method.

In the absence of a @PolyInitialized annotation which seems like the more correct solution, I would proposed always marking the return value as @Initialized to allow such chaining.