### PR TITLE
Add `@InheritableMustCall("close")` to java.sql.Connection

### DIFF
--- a/src/java.sql/share/classes/java/sql/Connection.java
+++ b/src/java.sql/share/classes/java/sql/Connection.java
@@ -25,6 +25,9 @@
 
 package java.sql;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.util.Properties;
 import java.util.concurrent.Executor;
 
@@ -82,6 +85,8 @@ import java.util.concurrent.Executor;
  * @see DatabaseMetaData
  * @since 1.1
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Connection  extends Wrapper, AutoCloseable {
 
     /**


### PR DESCRIPTION
`Connection`s should be closed before going out of scope.