### PR TITLE
Relax signedness specification in `Object`

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -34,6 +34,7 @@ import org.checkerframework.checker.lock.qual.GuardSatisfied;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signedness.qual.UnknownSignedness;
 import org.checkerframework.checker.tainting.qual.Untainted;
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.checkerframework.common.reflection.qual.GetClass;
@@ -86,7 +87,7 @@ public class Object {
     @SafeEffect
     @Pure
     @IntrinsicCandidate
-    public final native Class<? extends @MustCall() Object> getClass(@PolyUI @GuardSatisfied @UnknownInitialization Object this);
+    public final native Class<? extends @MustCall() Object> getClass(@PolyUI @GuardSatisfied @UnknownInitialization @UnknownSignedness Object this);
 
     /**
      * Returns a hash code value for the object. This method is
@@ -123,7 +124,7 @@ public class Object {
      */
     @Pure
     @IntrinsicCandidate
-    public native int hashCode(@GuardSatisfied Object this);
+    public native int hashCode(@GuardSatisfied @UnknownSignedness Object this);
 
     /**
      * Indicates whether some other object is "equal to" this one.


### PR DESCRIPTION
Merge together:
https://github.com/typetools/checker-framework/pull/5848
https://github.com/typetools/jdk/pull/173
https://github.com/codespecs/daikon/pull/474
https://github.com/plume-lib/multi-version-control/pull/221
https://github.com/plume-lib/plume-util/pull/295
