### PR TITLE
Add `@PolyPresent` annotation to `Optional#map`

### DIFF
--- a/src/java.base/share/classes/java/util/Optional.java
+++ b/src/java.base/share/classes/java/util/Optional.java
@@ -28,6 +28,7 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
+import org.checkerframework.checker.optional.qual.PolyPresent;
 import org.checkerframework.checker.optional.qual.Present;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
@@ -286,7 +287,8 @@ public final @NonNull class Optional<T> {
      *         present, otherwise an empty {@code Optional}
      * @throws NullPointerException if the mapping function is {@code null}
      */
-    public <U> Optional<U> map(Function<? super T, ? extends @Nullable U> mapper) {
+    public <U> @PolyPresent Optional<U> map(@PolyPresent Optional<T> this,
+            Function<? super T, ? extends @Nullable U> mapper) {
         Objects.requireNonNull(mapper);
         if (!isPresent()) {
             return empty();


### PR DESCRIPTION
The addition of the `@PolyPresent` annotation to `Optional#map` adds support for the following cases:

```java
String (Optional<String> optStr) {
  if (optStr.isPresent()) {
    // optStr is now refined @Present.
    // Calling .map on a present (or, for that matter, empty) optional
    // does not change its presence or emptiness
    optStr.map(s -> s + "foobar").get();
  } else {
    return "Empty optional";
  }
}
```

Test cases supporting this JDK annotation are drafted here: https://github.com/typetools/checker-framework/pull/6312/.