### PR TITLE
Added Confidential annotations for JDK

### DIFF
--- a/src/java.base/share/classes/java/io/PrintStream.java
+++ b/src/java.base/share/classes/java/io/PrintStream.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.checker.mustcall.qual.NotOwning;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signedness.qual.PolySigned;
+import org.checkerframework.checker.confidential.qual.NonConfidential;
 import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.qual.CFComment;
 
@@ -74,7 +75,7 @@ import java.nio.charset.UnsupportedCharsetException;
  */
 
 @CFComment({"lock: TODO: Should parameters be @GuardSatisfied, or is the default of @GuardedBy({}) appropriate? (@GuardedBy({}) is more conservative.)"})
-@AnnotatedFor({"formatter", "i18n", "index", "lock", "mustcall", "nullness", "signedness"})
+@AnnotatedFor({"formatter", "i18n", "index", "lock", "mustcall", "nullness", "signedness", "confidential"})
 public class PrintStream extends FilterOutputStream
     implements Appendable, Closeable
 {
@@ -790,7 +791,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param      c   The {@code char} to be printed
      */
-    public void print(@GuardSatisfied PrintStream this, char c) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential char c) {
         write(String.valueOf(c));
     }
 
@@ -804,7 +805,7 @@ public class PrintStream extends FilterOutputStream
      * @param      i   The {@code int} to be printed
      * @see        java.lang.Integer#toString(int)
      */
-    public void print(@GuardSatisfied PrintStream this, int i) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential int i) {
         write(String.valueOf(i));
     }
 
@@ -818,7 +819,7 @@ public class PrintStream extends FilterOutputStream
      * @param      l   The {@code long} to be printed
      * @see        java.lang.Long#toString(long)
      */
-    public void print(@GuardSatisfied PrintStream this, long l) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential long l) {
         write(String.valueOf(l));
     }
 
@@ -832,7 +833,7 @@ public class PrintStream extends FilterOutputStream
      * @param      f   The {@code float} to be printed
      * @see        java.lang.Float#toString(float)
      */
-    public void print(@GuardSatisfied PrintStream this, float f) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential float f) {
         write(String.valueOf(f));
     }
 
@@ -846,7 +847,7 @@ public class PrintStream extends FilterOutputStream
      * @param      d   The {@code double} to be printed
      * @see        java.lang.Double#toString(double)
      */
-    public void print(@GuardSatisfied PrintStream this, double d) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential double d) {
         write(String.valueOf(d));
     }
 
@@ -860,7 +861,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @throws  NullPointerException  If {@code s} is {@code null}
      */
-    public void print(@GuardSatisfied PrintStream this, @PolySigned char s[]) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential @PolySigned char s[]) {
         write(s);
     }
 
@@ -874,7 +875,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param      s   The {@code String} to be printed
      */
-    public void print(@GuardSatisfied PrintStream this, @Nullable String s) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential @Nullable String s) {
         write(String.valueOf(s));
     }
 
@@ -888,7 +889,7 @@ public class PrintStream extends FilterOutputStream
      * @param      obj   The {@code Object} to be printed
      * @see        java.lang.Object#toString()
      */
-    public void print(@GuardSatisfied PrintStream this, @Nullable Object obj) {
+    public void print(@GuardSatisfied PrintStream this, @NonConfidential @Nullable Object obj) {
         write(String.valueOf(obj));
     }
 
@@ -930,7 +931,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code char} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, char x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential char x) {
         if (getClass() == PrintStream.class) {
             writeln(String.valueOf(x));
         } else {
@@ -948,7 +949,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code int} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, int x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential int x) {
         if (getClass() == PrintStream.class) {
             writeln(String.valueOf(x));
         } else {
@@ -966,7 +967,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  a The {@code long} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, long x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential long x) {
         if (getClass() == PrintStream.class) {
             writeln(String.valueOf(x));
         } else {
@@ -984,7 +985,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code float} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, float x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential float x) {
         if (getClass() == PrintStream.class) {
             writeln(String.valueOf(x));
         } else {
@@ -1002,7 +1003,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code double} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, double x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential double x) {
         if (getClass() == PrintStream.class) {
             writeln(String.valueOf(x));
         } else {
@@ -1020,7 +1021,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  an array of chars to print.
      */
-    public void println(@GuardSatisfied PrintStream this, char[] x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential char[] x) {
         if (getClass() == PrintStream.class) {
             writeln(x);
         } else {
@@ -1038,7 +1039,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code String} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, @Nullable @Localized String x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential @Nullable @Localized String x) {
         if (getClass() == PrintStream.class) {
             writeln(String.valueOf(x));
         } else {
@@ -1058,7 +1059,7 @@ public class PrintStream extends FilterOutputStream
      *
      * @param x  The {@code Object} to be printed.
      */
-    public void println(@GuardSatisfied PrintStream this, @Nullable Object x) {
+    public void println(@GuardSatisfied PrintStream this, @NonConfidential @Nullable Object x) {
         String s = String.valueOf(x);
         if (getClass() == PrintStream.class) {
             // need to apply String.valueOf again since first invocation
@@ -1118,7 +1119,7 @@ public class PrintStream extends FilterOutputStream
      */
     @CFComment({"lock/nullness: The vararg arrays can actually be null, but let's not annotate them because passing null is bad style; see whether this annotation is useful."})
     @FormatMethod
-    public @NotOwning PrintStream printf(@GuardSatisfied PrintStream this, String format, @Nullable Object ... args) {
+    public @NotOwning @NonConfidential PrintStream printf(@GuardSatisfied PrintStream this, @NonConfidential String format, @NonConfidential @Nullable Object ... args) {
         return format(format, args);
     }
 
@@ -1171,7 +1172,7 @@ public class PrintStream extends FilterOutputStream
      * @since  1.5
      */
     @FormatMethod
-    public @NotOwning PrintStream printf(@GuardSatisfied PrintStream this, @Nullable Locale l, String format, @Nullable Object ... args) {
+    public @NotOwning @NonConfidential PrintStream printf(@GuardSatisfied PrintStream this, @Nullable Locale l, @NonConfidential String format, @NonConfidential @Nullable Object ... args) {
         return format(l, format, args);
     }
 

--- a/src/java.logging/share/classes/java/util/logging/Formatter.java
+++ b/src/java.logging/share/classes/java/util/logging/Formatter.java
@@ -27,6 +27,7 @@
 package java.util.logging;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.confidential.qual.NonConfidential;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 /**
@@ -43,7 +44,7 @@ import org.checkerframework.framework.qual.AnnotatedFor;
  * @since 1.4
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "confidential"})
 public abstract @UsesObjectEquals class Formatter {
 
     /**
@@ -63,7 +64,7 @@ public abstract @UsesObjectEquals class Formatter {
      * @param record the log record to be formatted.
      * @return the formatted log record
      */
-    public abstract String format(LogRecord record);
+    public abstract String format(@NonConfidential LogRecord record);
 
 
     /**

--- a/src/java.logging/share/classes/java/util/logging/Handler.java
+++ b/src/java.logging/share/classes/java/util/logging/Handler.java
@@ -27,6 +27,7 @@
 package java.util.logging;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.confidential.qual.NonConfidential;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.util.Objects;
@@ -52,7 +53,7 @@ import java.security.PrivilegedAction;
  * @since 1.4
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "confidential"})
 public abstract @UsesObjectEquals class Handler {
     private static final int offValue = Level.OFF.intValue();
     private final LogManager manager = LogManager.getLogManager();
@@ -138,7 +139,7 @@ public abstract @UsesObjectEquals class Handler {
      * @param  record  description of the log event. A null record is
      *                 silently ignored and is not published
      */
-    public abstract void publish(LogRecord record);
+    public abstract void publish(@NonConfidential LogRecord record);
 
     /**
      * Flush any buffered output.

--- a/src/java.logging/share/classes/java/util/logging/Logger.java
+++ b/src/java.logging/share/classes/java/util/logging/Logger.java
@@ -234,7 +234,7 @@ import static jdk.internal.logger.DefaultLoggerFinder.isSystem;
             "public boolean containsAll(@GuardSatisfied LinkedList<E> this, Collection<?> c);",
             "public int hashCode(@GuardSatisfied LinkedList<E> this);",
             "public boolean equals(@GuardSatisfied LinkedList<E> this, Object o);"})
-@AnnotatedFor({"index", "interning", "lock", "signature"})
+@AnnotatedFor({"index", "interning", "lock", "signature", "confidential"})
 public @UsesObjectEquals class Logger {
     private static final Handler emptyHandlers[] = new Handler[0];
     private static final int offValue = Level.OFF.intValue();
@@ -983,7 +983,7 @@ public @UsesObjectEquals class Logger {
      * @param record the LogRecord to be published
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, LogRecord record) {
+    public void log(@GuardSatisfied Logger this, @NonConfidential LogRecord record) {
         if (!isLoggable(record.getLevel())) {
             return;
         }
@@ -1049,7 +1049,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @Nullable String msg) {
+    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @Nullable String msg) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1072,7 +1072,7 @@ public @UsesObjectEquals class Logger {
      * @since 1.8
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @GuardSatisfied Supplier<String> msgSupplier) {
+    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @GuardSatisfied Supplier<String> msgSupplier) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1092,7 +1092,7 @@ public @UsesObjectEquals class Logger {
      * @param   param1  parameter to the message
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @Nullable String msg, @GuardSatisfied @Nullable Object param1) {
+    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @Nullable String msg, @NonConfidential @GuardSatisfied @Nullable Object param1) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1114,7 +1114,7 @@ public @UsesObjectEquals class Logger {
      * @param   params  array of parameters to the message
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @Nullable String msg, @Nullable Object params @GuardSatisfied @Nullable []) {
+    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @Nullable String msg, @NonConfidential @Nullable Object params @GuardSatisfied @Nullable []) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1140,7 +1140,7 @@ public @UsesObjectEquals class Logger {
      * @param   thrown  Throwable associated with log message.
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @Nullable String msg, @GuardSatisfied @Nullable Throwable thrown) {
+    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @Nullable String msg, @NonConfidential @GuardSatisfied @Nullable Throwable thrown) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1169,7 +1169,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @GuardSatisfied @Nullable Throwable thrown, @GuardSatisfied Supplier<String> msgSupplier) {
+    public void log(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @GuardSatisfied @Nullable Throwable thrown, @NonConfidential @GuardSatisfied Supplier<String> msgSupplier) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1196,7 +1196,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void logp(@GuardSatisfied Logger this, @GuardSatisfied Level level, @Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
+    public void logp(@GuardSatisfied Logger this, @GuardSatisfied Level level, @NonConfidential @Nullable String sourceClass, @NonConfidential @Nullable String sourceMethod, @NonConfidential @Nullable String msg) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1223,8 +1223,8 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void logp(@GuardSatisfied Logger this, Level level, @Nullable String sourceClass, @Nullable String sourceMethod,
-                     Supplier<String> msgSupplier) {
+    public void logp(@GuardSatisfied Logger this, Level level, @NonConfidential @Nullable String sourceClass, @NonConfidential @Nullable String sourceMethod,
+                     @NonConfidential Supplier<String> msgSupplier) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1249,8 +1249,8 @@ public @UsesObjectEquals class Logger {
      * @param   param1    Parameter to the log message.
      */
     @SideEffectFree
-    public void logp(@GuardSatisfied Logger this, Level level, @Nullable String sourceClass, @Nullable String sourceMethod,
-                                                @Nullable String msg, @Nullable Object param1) {
+    public void logp(@GuardSatisfied Logger this, Level level, @NonConfidential @Nullable String sourceClass, @NonConfidential @Nullable String sourceMethod,
+                     @NonConfidential @Nullable String msg, @NonConfidential @Nullable Object param1) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1277,8 +1277,8 @@ public @UsesObjectEquals class Logger {
      * @param   params  Array of parameters to the message
      */
     @SideEffectFree
-    public void logp(@GuardSatisfied Logger this, Level level, @Nullable String sourceClass, @Nullable String sourceMethod,
-                                                @Nullable String msg, @Nullable Object params @Nullable []) {
+    public void logp(@GuardSatisfied Logger this, Level level, @NonConfidential @Nullable String sourceClass, @NonConfidential @Nullable String sourceMethod,
+                     @NonConfidential @Nullable String msg, @NonConfidential @Nullable Object params @Nullable []) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1309,8 +1309,8 @@ public @UsesObjectEquals class Logger {
      * @param   thrown  Throwable associated with log message.
      */
     @SideEffectFree
-    public void logp(@GuardSatisfied Logger this, Level level, @Nullable String sourceClass, @Nullable String sourceMethod,
-                     @Nullable String msg, @Nullable Throwable thrown) {
+    public void logp(@GuardSatisfied Logger this, Level level, @NonConfidential @Nullable String sourceClass, @NonConfidential @Nullable String sourceMethod,
+                     @NonConfidential @Nullable String msg, @NonConfidential @Nullable Throwable thrown) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1344,8 +1344,8 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void logp(@GuardSatisfied Logger this, Level level, @Nullable String sourceClass, @Nullable String sourceMethod,
-                     @Nullable Throwable thrown, Supplier<String> msgSupplier) {
+    public void logp(@GuardSatisfied Logger this, Level level, @NonConfidential @Nullable String sourceClass, @NonConfidential @Nullable String sourceMethod,
+                     @NonConfidential @Nullable Throwable thrown, @NonConfidential Supplier<String> msgSupplier) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1515,8 +1515,8 @@ public @UsesObjectEquals class Logger {
      * @param   params  Parameters to the message (optional, may be none).
      * @since 1.8
      */
-    public void logrb(Level level, String sourceClass, String sourceMethod,
-                      ResourceBundle bundle, String msg, Object... params) {
+    public void logrb(Level level, @NonConfidential String sourceClass, @NonConfidential String sourceMethod,
+                      ResourceBundle bundle, @NonConfidential String msg, @NonConfidential Object... params) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1548,7 +1548,7 @@ public @UsesObjectEquals class Logger {
      * @param   params  Parameters to the message (optional, may be none).
      * @since 9
      */
-    public void logrb(Level level, ResourceBundle bundle, String msg, Object... params) {
+    public void logrb(Level level, ResourceBundle bundle, @NonConfidential String msg, @NonConfidential Object... params) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1628,8 +1628,8 @@ public @UsesObjectEquals class Logger {
      * @param   thrown  Throwable associated with the log message.
      * @since 1.8
      */
-    public void logrb(Level level, String sourceClass, String sourceMethod,
-                      ResourceBundle bundle, String msg, Throwable thrown) {
+    public void logrb(Level level, @NonConfidential String sourceClass, @NonConfidential String sourceMethod,
+                      ResourceBundle bundle, @NonConfidential String msg, @NonConfidential Throwable thrown) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1666,8 +1666,8 @@ public @UsesObjectEquals class Logger {
      * @param   thrown  Throwable associated with the log message.
      * @since 9
      */
-    public void logrb(Level level, ResourceBundle bundle, String msg,
-            Throwable thrown) {
+    public void logrb(Level level, ResourceBundle bundle, @NonConfidential String msg,
+                      @NonConfidential Throwable thrown) {
         if (!isLoggable(level)) {
             return;
         }
@@ -1823,7 +1823,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void severe(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void severe(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.SEVERE, msg);
     }
 
@@ -1837,7 +1837,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void warning(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void warning(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.WARNING, msg);
     }
 
@@ -1851,7 +1851,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void info(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void info(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.INFO, msg);
     }
 
@@ -1865,7 +1865,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void config(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void config(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.CONFIG, msg);
     }
 
@@ -1879,7 +1879,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void fine(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void fine(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.FINE, msg);
     }
 
@@ -1893,7 +1893,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void finer(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void finer(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.FINER, msg);
     }
 
@@ -1907,7 +1907,7 @@ public @UsesObjectEquals class Logger {
      * @param   msg     The string message (or a key in the message catalog)
      */
     @SideEffectFree
-    public void finest(@GuardSatisfied Logger this, @Nullable String msg) {
+    public void finest(@GuardSatisfied Logger this, @NonConfidential @Nullable String msg) {
         log(Level.FINEST, msg);
     }
 
@@ -1930,7 +1930,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void severe(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void severe(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.SEVERE, msgSupplier);
     }
 
@@ -1948,7 +1948,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void warning(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void warning(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.WARNING, msgSupplier);
     }
 
@@ -1966,7 +1966,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void info(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void info(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.INFO, msgSupplier);
     }
 
@@ -1984,7 +1984,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void config(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void config(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.CONFIG, msgSupplier);
     }
 
@@ -2002,7 +2002,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void fine(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void fine(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.FINE, msgSupplier);
     }
 
@@ -2020,7 +2020,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void finer(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void finer(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.FINER, msgSupplier);
     }
 
@@ -2038,7 +2038,7 @@ public @UsesObjectEquals class Logger {
      * @since   1.8
      */
     @SideEffectFree
-    public void finest(@GuardSatisfied Logger this, Supplier<String> msgSupplier) {
+    public void finest(@GuardSatisfied Logger this, @NonConfidential Supplier<String> msgSupplier) {
         log(Level.FINEST, msgSupplier);
     }
 


### PR DESCRIPTION
Migrated stub files annotations from confidential checker to JDK classes if applicable.
Associated with checker framework pull request https://github.com/typetools/checker-framework/pull/6880.