### PR TITLE
Index parameter annotations

### DIFF
--- a/src/java.base/share/classes/java/util/AbstractList.java
+++ b/src/java.base/share/classes/java/util/AbstractList.java
@@ -806,13 +806,13 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             this.modCount = root.modCount;
         }
 
-        public E set(int index, E element) {
+        public E set(@IndexFor({"this"}) int index, E element) {
             Objects.checkIndex(index, size);
             checkForComodification();
             return root.set(offset + index, element);
         }
 
-        public E get(int index) {
+        public E get(@IndexFor({"this"}) int index) {
             Objects.checkIndex(index, size);
             checkForComodification();
             return root.get(offset + index);
@@ -824,14 +824,14 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             return size;
         }
 
-        public void add(int index, E element) {
+        public void add(@IndexOrHigh({"this"}) int index, E element) {
             rangeCheckForAdd(index);
             checkForComodification();
             root.add(offset + index, element);
             updateSizeAndModCount(1);
         }
 
-        public E remove(int index) {
+        public E remove(@IndexFor({"this"}) int index) {
             Objects.checkIndex(index, size);
             checkForComodification();
             E result = root.remove(offset + index);
@@ -839,7 +839,7 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             return result;
         }
 
-        protected void removeRange(int fromIndex, int toIndex) {
+        protected void removeRange(@IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
             checkForComodification();
             root.removeRange(offset + fromIndex, offset + toIndex);
             updateSizeAndModCount(fromIndex - toIndex);
@@ -849,7 +849,7 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             return addAll(size, c);
         }
 
-        public boolean addAll(int index, Collection<? extends E> c) {
+        public boolean addAll(@IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
             rangeCheckForAdd(index);
             int cSize = c.size();
             if (cSize==0)
@@ -864,7 +864,7 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             return listIterator();
         }
 
-        public ListIterator<E> listIterator(int index) {
+        public ListIterator<E> listIterator(@IndexOrHigh({"this"}) int index) {
             checkForComodification();
             rangeCheckForAdd(index);
 
@@ -925,7 +925,7 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             };
         }
 
-        public List<E> subList(int fromIndex, int toIndex) {
+        public List<E> subList(@IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
             subListRangeCheck(fromIndex, toIndex, size);
             return new SubList<>(this, fromIndex, toIndex);
         }
@@ -974,7 +974,7 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             super(parent, fromIndex, toIndex);
         }
 
-        public List<E> subList(int fromIndex, int toIndex) {
+        public List<E> subList(@IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
             subListRangeCheck(fromIndex, toIndex, size);
             return new RandomAccessSubList<>(this, fromIndex, toIndex);
         }

--- a/src/java.base/share/classes/java/util/AbstractList.java
+++ b/src/java.base/share/classes/java/util/AbstractList.java
@@ -21,7 +21,6 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- * 
  */
 
 package java.util;

--- a/src/java.base/share/classes/java/util/AbstractList.java
+++ b/src/java.base/share/classes/java/util/AbstractList.java
@@ -805,6 +805,7 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             this.size = toIndex - fromIndex;
             this.modCount = root.modCount;
         }
+
         public E set(@IndexFor({"this"}) int index, E element) {
             Objects.checkIndex(index, size);
             checkForComodification();

--- a/src/java.base/share/classes/java/util/AbstractList.java
+++ b/src/java.base/share/classes/java/util/AbstractList.java
@@ -21,6 +21,7 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
+ * 
  */
 
 package java.util;

--- a/src/java.base/share/classes/java/util/AbstractList.java
+++ b/src/java.base/share/classes/java/util/AbstractList.java
@@ -805,7 +805,6 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
             this.size = toIndex - fromIndex;
             this.modCount = root.modCount;
         }
-
         public E set(@IndexFor({"this"}) int index, E element) {
             Objects.checkIndex(index, size);
             checkForComodification();

--- a/src/java.base/share/classes/java/util/AbstractSequentialList.java
+++ b/src/java.base/share/classes/java/util/AbstractSequentialList.java
@@ -25,6 +25,8 @@
 
 package java.util;
 
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.PolyGrowShrink;
 import org.checkerframework.checker.index.qual.Shrinkable;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
@@ -95,7 +97,7 @@ public abstract class AbstractSequentialList<E> extends AbstractList<E> {
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
     @Pure
-    public E get(@GuardSatisfied AbstractSequentialList<E> this, int index) {
+    public E get(@GuardSatisfied AbstractSequentialList<E> this, @IndexFor({"this"}) int index) {
         try {
             return listIterator(index).next();
         } catch (NoSuchElementException exc) {
@@ -122,7 +124,7 @@ public abstract class AbstractSequentialList<E> extends AbstractList<E> {
      * @throws IllegalArgumentException      {@inheritDoc}
      * @throws IndexOutOfBoundsException     {@inheritDoc}
      */
-    public E set(@GuardSatisfied AbstractSequentialList<E> this, int index, E element) {
+    public E set(@GuardSatisfied AbstractSequentialList<E> this, @IndexFor({"this"}) int index, E element) {
         try {
             ListIterator<E> e = listIterator(index);
             E oldVal = e.next();
@@ -153,7 +155,7 @@ public abstract class AbstractSequentialList<E> extends AbstractList<E> {
      * @throws IllegalArgumentException      {@inheritDoc}
      * @throws IndexOutOfBoundsException     {@inheritDoc}
      */
-    public void add(@GuardSatisfied AbstractSequentialList<E> this, int index, E element) {
+    public void add(@GuardSatisfied AbstractSequentialList<E> this, @IndexOrHigh({"this"}) int index, E element) {
         try {
             listIterator(index).add(element);
         } catch (NoSuchElementException exc) {
@@ -178,7 +180,7 @@ public abstract class AbstractSequentialList<E> extends AbstractList<E> {
      * @throws UnsupportedOperationException {@inheritDoc}
      * @throws IndexOutOfBoundsException     {@inheritDoc}
      */
-    public E remove(@GuardSatisfied @Shrinkable AbstractSequentialList<E> this, int index) {
+    public E remove(@GuardSatisfied @Shrinkable AbstractSequentialList<E> this, @IndexFor({"this"}) int index) {
         try {
             ListIterator<E> e = listIterator(index);
             E outCast = e.next();
@@ -221,7 +223,7 @@ public abstract class AbstractSequentialList<E> extends AbstractList<E> {
      * @throws IllegalArgumentException      {@inheritDoc}
      * @throws IndexOutOfBoundsException     {@inheritDoc}
      */
-    public boolean addAll(@GuardSatisfied AbstractSequentialList<E> this, int index, Collection<? extends E> c) {
+    public boolean addAll(@GuardSatisfied AbstractSequentialList<E> this, @IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
         try {
             boolean modified = false;
             ListIterator<E> e1 = listIterator(index);
@@ -261,5 +263,5 @@ public abstract class AbstractSequentialList<E> extends AbstractList<E> {
      *         sequence)
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public abstract @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink AbstractSequentialList<E> this, int index);
+    public abstract @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink AbstractSequentialList<E> this, @IndexOrHigh({"this"}) int index);
 }

--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -26,6 +26,8 @@
 package java.util;
 
 import org.checkerframework.checker.index.qual.GTENegativeOne;
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.PolyGrowShrink;
 import org.checkerframework.checker.index.qual.Shrinkable;
@@ -460,7 +462,7 @@ public class ArrayList<E> extends AbstractList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
     @Pure
-    public E get(@GuardSatisfied ArrayList<E> this, @NonNegative int index) {
+    public E get(@GuardSatisfied ArrayList<E> this, @IndexFor({"this"}) int index) {
         Objects.checkIndex(index, size);
         return elementData(index);
     }
@@ -475,7 +477,7 @@ public class ArrayList<E> extends AbstractList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
     @SideEffectsOnly("this")
-    public E set(@GuardSatisfied ArrayList<E> this, @NonNegative int index, E element) {
+    public E set(@GuardSatisfied ArrayList<E> this, @IndexFor({"this"}) int index, E element) {
         Objects.checkIndex(index, size);
         E oldValue = elementData(index);
         elementData[index] = element;
@@ -519,7 +521,7 @@ public class ArrayList<E> extends AbstractList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
     @SideEffectsOnly("this")
-    public void add(@GuardSatisfied ArrayList<E> this, @NonNegative int index, E element) {
+    public void add(@GuardSatisfied ArrayList<E> this, @IndexOrHigh({"this"}) int index, E element) {
         rangeCheckForAdd(index);
         modCount++;
         final int s;
@@ -542,7 +544,7 @@ public class ArrayList<E> extends AbstractList<E>
      * @return the element that was removed from the list
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public E remove(@GuardSatisfied @Shrinkable ArrayList<E> this, @NonNegative int index) {
+    public E remove(@GuardSatisfied @Shrinkable ArrayList<E> this, @IndexFor({"this"}) int index) {
         Objects.checkIndex(index, size);
         final Object[] es = elementData;
 
@@ -742,7 +744,7 @@ public class ArrayList<E> extends AbstractList<E>
      * @throws NullPointerException if the specified collection is null
      */
     @SideEffectsOnly("this")
-    public boolean addAll(@GuardSatisfied ArrayList<E> this, @NonNegative int index, Collection<? extends E> c) {
+    public boolean addAll(@GuardSatisfied ArrayList<E> this, @IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
         rangeCheckForAdd(index);
 
         Object[] a = c.toArray();
@@ -965,7 +967,7 @@ public class ArrayList<E> extends AbstractList<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink ArrayList<E> this, @NonNegative int index) {
+    public @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink ArrayList<E> this, @IndexOrHigh({"this"}) int index) {
         rangeCheckForAdd(index);
         return new ListItr(index);
     }
@@ -1155,7 +1157,7 @@ public class ArrayList<E> extends AbstractList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      * @throws IllegalArgumentException {@inheritDoc}
      */
-    public @PolyGrowShrink List<E> subList(@GuardSatisfied @PolyGrowShrink ArrayList<E> this, @NonNegative int fromIndex, @NonNegative int toIndex) {
+    public @PolyGrowShrink List<E> subList(@GuardSatisfied @PolyGrowShrink ArrayList<E> this, @IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
         subListRangeCheck(fromIndex, toIndex, size);
         return new SubList<>(this, fromIndex, toIndex);
     }
@@ -1188,7 +1190,7 @@ public class ArrayList<E> extends AbstractList<E>
             this.modCount = parent.modCount;
         }
 
-        public E set(@NonNegative int index, E element) {
+        public E set(@IndexFor({"this"}) int index, E element) {
             Objects.checkIndex(index, size);
             checkForComodification();
             E oldValue = root.elementData(offset + index);
@@ -1196,7 +1198,7 @@ public class ArrayList<E> extends AbstractList<E>
             return oldValue;
         }
 
-        public E get(@NonNegative int index) {
+        public E get(@IndexFor({"this"}) int index) {
             Objects.checkIndex(index, size);
             checkForComodification();
             return root.elementData(offset + index);
@@ -1208,14 +1210,14 @@ public class ArrayList<E> extends AbstractList<E>
             return size;
         }
 
-        public void add(@NonNegative int index, E element) {
+        public void add(@IndexOrHigh({"this"}) int index, E element) {
             rangeCheckForAdd(index);
             checkForComodification();
             root.add(offset + index, element);
             updateSizeAndModCount(1);
         }
 
-        public E remove(@NonNegative int index) {
+        public E remove(@IndexFor({"this"}) int index) {
             Objects.checkIndex(index, size);
             checkForComodification();
             E result = root.remove(offset + index);
@@ -1233,7 +1235,7 @@ public class ArrayList<E> extends AbstractList<E>
             return addAll(this.size, c);
         }
 
-        public boolean addAll(@NonNegative int index, Collection<? extends E> c) {
+        public boolean addAll(@IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
             rangeCheckForAdd(index);
             int cSize = c.size();
             if (cSize==0)
@@ -1334,7 +1336,7 @@ public class ArrayList<E> extends AbstractList<E>
             return listIterator();
         }
 
-        public ListIterator<E> listIterator(@NonNegative int index) {
+        public ListIterator<E> listIterator(@IndexOrHigh({"this"}) int index) {
             checkForComodification();
             rangeCheckForAdd(index);
 
@@ -1453,7 +1455,7 @@ public class ArrayList<E> extends AbstractList<E>
             };
         }
 
-        public List<E> subList(int fromIndex, int toIndex) {
+        public List<E> subList(@IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
             subListRangeCheck(fromIndex, toIndex, size);
             return new SubList<>(this, fromIndex, toIndex);
         }

--- a/src/java.base/share/classes/java/util/LinkedList.java
+++ b/src/java.base/share/classes/java/util/LinkedList.java
@@ -26,6 +26,8 @@
 package java.util;
 
 import org.checkerframework.checker.index.qual.GTENegativeOne;
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.PolyGrowShrink;
 import org.checkerframework.checker.index.qual.Shrinkable;
@@ -434,7 +436,7 @@ public class LinkedList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      * @throws NullPointerException if the specified collection is null
      */
-    public boolean addAll(@GuardSatisfied LinkedList<E> this, @NonNegative int index, Collection<? extends E> c) {
+    public boolean addAll(@GuardSatisfied LinkedList<E> this, @IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
         checkPositionIndex(index);
 
         Object[] a = c.toArray();
@@ -505,7 +507,7 @@ public class LinkedList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
     @Pure
-    public E get(@GuardSatisfied LinkedList<E> this, @NonNegative int index) {
+    public E get(@GuardSatisfied LinkedList<E> this, @IndexFor({"this"}) int index) {
         checkElementIndex(index);
         return node(index).item;
     }
@@ -519,7 +521,7 @@ public class LinkedList<E>
      * @return the element previously at the specified position
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public E set(@GuardSatisfied LinkedList<E> this, @NonNegative int index, E element) {
+    public E set(@GuardSatisfied LinkedList<E> this, @IndexFor({"this"}) int index, E element) {
         checkElementIndex(index);
         Node<E> x = node(index);
         E oldVal = x.item;
@@ -536,7 +538,7 @@ public class LinkedList<E>
      * @param element element to be inserted
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public void add(@GuardSatisfied LinkedList<E> this, @NonNegative int index, E element) {
+    public void add(@GuardSatisfied LinkedList<E> this, @IndexOrHigh({"this"}) int index, E element) {
         checkPositionIndex(index);
 
         if (index == size)
@@ -554,7 +556,7 @@ public class LinkedList<E>
      * @return the element previously at the specified position
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public E remove(@GuardSatisfied @Shrinkable LinkedList<E> this, @NonNegative int index) {
+    public E remove(@GuardSatisfied @Shrinkable LinkedList<E> this, @IndexFor({"this"}) int index) {
         checkElementIndex(index);
         return unlink(node(index));
     }
@@ -901,7 +903,7 @@ public class LinkedList<E>
      * @throws IndexOutOfBoundsException {@inheritDoc}
      * @see List#listIterator(int)
      */
-    public @PolyGrowShrink @PolyNonEmpty ListIterator<E> listIterator(@PolyGrowShrink @PolyNonEmpty LinkedList<E> this, @NonNegative int index) {
+    public @PolyGrowShrink @PolyNonEmpty ListIterator<E> listIterator(@PolyGrowShrink @PolyNonEmpty LinkedList<E> this, @IndexOrHigh({"this"}) int index) {
         checkPositionIndex(index);
         return new ListItr(index);
     }

--- a/src/java.base/share/classes/java/util/Vector.java
+++ b/src/java.base/share/classes/java/util/Vector.java
@@ -26,6 +26,8 @@
 package java.util;
 
 import org.checkerframework.checker.index.qual.GTENegativeOne;
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.PolyGrowShrink;
 import org.checkerframework.checker.index.qual.Shrinkable;
@@ -780,7 +782,7 @@ public class Vector<E>
      * @since 1.2
      */
     @Pure
-    public synchronized E get(@GuardSatisfied Vector<E> this, @NonNegative int index) {
+    public synchronized E get(@GuardSatisfied Vector<E> this, @IndexFor({"this"}) int index) {
         if (index >= elementCount)
             throw new ArrayIndexOutOfBoundsException(index);
 
@@ -798,7 +800,7 @@ public class Vector<E>
      *         ({@code index < 0 || index >= size()})
      * @since 1.2
      */
-    public synchronized E set(@GuardSatisfied Vector<E> this, @NonNegative int index, E element) {
+    public synchronized E set(@GuardSatisfied Vector<E> this, @IndexFor({"this"}) int index, E element) {
         if (index >= elementCount)
             throw new ArrayIndexOutOfBoundsException(index);
 
@@ -860,7 +862,7 @@ public class Vector<E>
      *         ({@code index < 0 || index > size()})
      * @since 1.2
      */
-    public void add(@GuardSatisfied Vector<E> this, @NonNegative int index, E element) {
+    public void add(@GuardSatisfied Vector<E> this, @IndexOrHigh({"this"}) int index, E element) {
         insertElementAt(element, index);
     }
 
@@ -875,7 +877,7 @@ public class Vector<E>
      *         ({@code index < 0 || index >= size()})
      * @since 1.2
      */
-    public synchronized E remove(@GuardSatisfied @Shrinkable Vector<E> this, @NonNegative int index) {
+    public synchronized E remove(@GuardSatisfied @Shrinkable Vector<E> this, @IndexFor({"this"}) int index) {
         modCount++;
         if (index >= elementCount)
             throw new ArrayIndexOutOfBoundsException(index);
@@ -1067,7 +1069,7 @@ public class Vector<E>
      * @throws NullPointerException if the specified collection is null
      * @since 1.2
      */
-    public synchronized boolean addAll(@GuardSatisfied Vector<E> this, @NonNegative int index, Collection<? extends E> c) {
+    public synchronized boolean addAll(@GuardSatisfied Vector<E> this, @IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
         if (index < 0 || index > elementCount)
             throw new ArrayIndexOutOfBoundsException(index);
 
@@ -1160,7 +1162,7 @@ public class Vector<E>
      *         {@code (fromIndex > toIndex)}
      */
     @SideEffectFree
-    public synchronized @PolyGrowShrink List<E> subList(@GuardSatisfied @PolyGrowShrink Vector<E> this, int fromIndex, int toIndex) {
+    public synchronized @PolyGrowShrink List<E> subList(@GuardSatisfied @PolyGrowShrink Vector<E> this, @IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
         return Collections.synchronizedList(super.subList(fromIndex, toIndex),
                                             this);
     }
@@ -1243,7 +1245,7 @@ public class Vector<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public synchronized @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink Vector<E> this, @NonNegative int index) {
+    public synchronized @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink Vector<E> this, @IndexOrHigh({"this"}) int index) {
         if (index < 0 || index > elementCount)
             throw new IndexOutOfBoundsException("Index: "+index);
         return new ListItr(index);

--- a/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
+++ b/src/java.base/share/classes/java/util/concurrent/CopyOnWriteArrayList.java
@@ -34,6 +34,8 @@
 
 package java.util.concurrent;
 
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.PolyGrowShrink;
 import org.checkerframework.checker.index.qual.Shrinkable;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
@@ -416,7 +418,7 @@ public class CopyOnWriteArrayList<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public E get(int index) {
+    public E get(@IndexFor({"this"}) int index) {
         return elementAt(getArray(), index);
     }
 
@@ -426,7 +428,7 @@ public class CopyOnWriteArrayList<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public E set(int index, E element) {
+    public E set(@IndexFor({"this"}) int index, E element) {
         synchronized (lock) {
             Object[] es = getArray();
             E oldValue = elementAt(es, index);
@@ -466,7 +468,7 @@ public class CopyOnWriteArrayList<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public void add(int index, E element) {
+    public void add(@IndexOrHigh({"this"}) int index, E element) {
         synchronized (lock) {
             Object[] es = getArray();
             int len = es.length;
@@ -494,7 +496,7 @@ public class CopyOnWriteArrayList<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public E remove(@GuardSatisfied @Shrinkable CopyOnWriteArrayList<E> this, int index) {
+    public E remove(@GuardSatisfied @Shrinkable CopyOnWriteArrayList<E> this, @IndexFor({"this"}) int index) {
         synchronized (lock) {
             Object[] es = getArray();
             int len = es.length;
@@ -795,7 +797,7 @@ public class CopyOnWriteArrayList<E>
      * @throws NullPointerException if the specified collection is null
      * @see #add(int,Object)
      */
-    public boolean addAll(int index, Collection<? extends E> c) {
+    public boolean addAll(@IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
         Object[] cs = c.toArray();
         synchronized (lock) {
             Object[] es = getArray();
@@ -1072,7 +1074,7 @@ public class CopyOnWriteArrayList<E>
      *
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink CopyOnWriteArrayList<E> this, int index) {
+    public @PolyGrowShrink ListIterator<E> listIterator(@PolyGrowShrink CopyOnWriteArrayList<E> this, @IndexOrHigh({"this"}) int index) {
         Object[] es = getArray();
         int len = es.length;
         if (index < 0 || index > len)
@@ -1201,7 +1203,7 @@ public class CopyOnWriteArrayList<E>
      * @return a view of the specified range within this list
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public @PolyGrowShrink List<E> subList(@PolyGrowShrink CopyOnWriteArrayList<E> this, int fromIndex, int toIndex) {
+    public @PolyGrowShrink List<E> subList(@PolyGrowShrink CopyOnWriteArrayList<E> this, @IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
         synchronized (lock) {
             Object[] es = getArray();
             int len = es.length;
@@ -1378,7 +1380,7 @@ public class CopyOnWriteArrayList<E>
             return !it.hasNext();
         }
 
-        public E set(int index, E element) {
+        public E set(@IndexFor({"this"}) int index, E element) {
             synchronized (lock) {
                 rangeCheck(index);
                 checkForComodification();
@@ -1388,7 +1390,7 @@ public class CopyOnWriteArrayList<E>
             }
         }
 
-        public E get(int index) {
+        public E get(@IndexFor({"this"}) int index) {
             synchronized (lock) {
                 rangeCheck(index);
                 checkForComodification();
@@ -1415,7 +1417,7 @@ public class CopyOnWriteArrayList<E>
             return true;
         }
 
-        public void add(int index, E element) {
+        public void add(@IndexOrHigh({"this"}) int index, E element) {
             synchronized (lock) {
                 checkForComodification();
                 rangeCheckForAdd(index);
@@ -1435,7 +1437,7 @@ public class CopyOnWriteArrayList<E>
             }
         }
 
-        public boolean addAll(int index, Collection<? extends E> c) {
+        public boolean addAll(@IndexOrHigh({"this"}) int index, Collection<? extends E> c) {
             synchronized (lock) {
                 rangeCheckForAdd(index);
                 final Object[] oldArray = getArrayChecked();
@@ -1455,7 +1457,7 @@ public class CopyOnWriteArrayList<E>
             }
         }
 
-        public E remove(int index) {
+        public E remove(@IndexFor({"this"}) int index) {
             synchronized (lock) {
                 rangeCheck(index);
                 checkForComodification();
@@ -1485,7 +1487,7 @@ public class CopyOnWriteArrayList<E>
             return listIterator(0);
         }
 
-        public ListIterator<E> listIterator(int index) {
+        public ListIterator<E> listIterator(@IndexOrHigh({"this"}) int index) {
             synchronized (lock) {
                 checkForComodification();
                 rangeCheckForAdd(index);
@@ -1494,7 +1496,7 @@ public class CopyOnWriteArrayList<E>
             }
         }
 
-        public List<E> subList(int fromIndex, int toIndex) {
+        public List<E> subList(@IndexOrHigh({"this"}) int fromIndex, @IndexOrHigh({"this"}) int toIndex) {
             synchronized (lock) {
                 checkForComodification();
                 if (fromIndex < 0 || toIndex > size || fromIndex > toIndex)


### PR DESCRIPTION
Below is the Jdk annotation plan by Vlastimil regarding growonly-checker. This PR contains Stage 2 initial annotating effort.
Relevant checker-framework PR: https://github.com/typetools/checker-framework/pull/7206
Relevant plum-util PR: https://github.com/plume-lib/plume-util/pull/529

- ~Find JDK methods that can shrink lists (such as remove) and annotate their this parameter as @Shrinkable.~
- **Find JDK methods that accept indices (such as get) and annotate their parameters, mostly with IndexFor and IndexOrHigh.**
- Find JDK methods that return an index or length of the list (such as size) and annotate their return type, mostly
with IndexFor or IndexOrHigh.
- Modify the upper bound-checker to invalidate upper-bound qualifiers for lists on every method call, unless the list
is GrowOnly.