### PR TITLE
Added null annotations based on javadoc for the public nio classes

### DIFF
--- a/src/java.base/share/classes/java/nio/file/FileStore.java
+++ b/src/java.base/share/classes/java/nio/file/FileStore.java
@@ -27,6 +27,7 @@ package java.nio.file;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.nio.file.attribute.*;
 import java.io.IOException;
@@ -46,7 +47,7 @@ import java.io.IOException;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullness"})
 public abstract @UsesObjectEquals class FileStore {
 
     /**
@@ -215,7 +216,7 @@ public abstract @UsesObjectEquals class FileStore {
      * @return  a file store attribute view of the specified type or
      *          {@code null} if the attribute view is not available
      */
-    public abstract <V extends FileStoreAttributeView> V
+    public abstract <V extends @Nullable FileStoreAttributeView> V
         getFileStoreAttributeView(Class<V> type);
 
     /**
@@ -251,5 +252,5 @@ public abstract @UsesObjectEquals class FileStore {
      * @throws  IOException
      *          if an I/O error occurs
      */
-    public abstract Object getAttribute(String attribute) throws IOException;
+    public abstract @Nullable Object getAttribute(String attribute) throws IOException;
 }

--- a/src/java.base/share/classes/java/nio/file/FileSystems.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystems.java
@@ -27,6 +27,7 @@ package java.nio.file;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.nio.file.spi.FileSystemProvider;
 import java.net.URI;
@@ -89,7 +90,7 @@ import sun.nio.fs.DefaultFileSystemProvider;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullness"})
 public final @UsesObjectEquals class FileSystems {
     private FileSystems() { }
 
@@ -331,7 +332,7 @@ public final @UsesObjectEquals class FileSystems {
      *          if a security manager is installed and it denies an unspecified
      *          permission required by the file system provider implementation
      */
-    public static FileSystem newFileSystem(URI uri, Map<String,?> env, ClassLoader loader)
+    public static FileSystem newFileSystem(URI uri, Map<String,?> env, @Nullable ClassLoader loader)
         throws IOException
     {
         String scheme = uri.getScheme();
@@ -398,7 +399,7 @@ public final @UsesObjectEquals class FileSystems {
      *          permission
      */
     public static FileSystem newFileSystem(Path path,
-                                           ClassLoader loader)
+                                           @Nullable ClassLoader loader)
         throws IOException
     {
         return newFileSystem(path, Map.of(), loader);
@@ -521,7 +522,7 @@ public final @UsesObjectEquals class FileSystems {
      * @since 13
      */
     public static FileSystem newFileSystem(Path path, Map<String,?> env,
-                                           ClassLoader loader)
+                                           @Nullable ClassLoader loader)
         throws IOException
     {
         if (path == null)

--- a/src/java.base/share/classes/java/nio/file/FileVisitor.java
+++ b/src/java.base/share/classes/java/nio/file/FileVisitor.java
@@ -28,6 +28,9 @@ package java.nio.file;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A visitor of files. An implementation of this interface is provided to the
  * {@link Files#walkFileTree Files.walkFileTree} methods to visit each file in
@@ -95,6 +98,7 @@ import java.io.IOException;
  * @since 1.7
  */
 
+@AnnotatedFor({"nullness"})
 public interface FileVisitor<T> {
 
     /**
@@ -172,6 +176,6 @@ public interface FileVisitor<T> {
      * @throws  IOException
      *          if an I/O error occurs
      */
-    FileVisitResult postVisitDirectory(T dir, IOException exc)
+    FileVisitResult postVisitDirectory(T dir, @Nullable IOException exc)
         throws IOException;
 }

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -35,6 +35,7 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.dataflow.qual.SideEffectsOnly;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -103,7 +104,7 @@ import sun.nio.fs.AbstractFileSystemProvider;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning", "mustcall", "signedness"})
+@AnnotatedFor({"interning", "mustcall", "signedness", "nullness"})
 public final @UsesObjectEquals class Files {
     // buffer size used for reading and writing
     private static final int BUFFER_SIZE = 8192;
@@ -895,8 +896,8 @@ public final @UsesObjectEquals class Files {
      */
     @ReleasesNoLocks
     public static Path createTempFile(Path dir,
-                                      String prefix,
-                                      String suffix,
+                                      @Nullable String prefix,
+                                      @Nullable String suffix,
                                       FileAttribute<?>... attrs)
         throws IOException
     {
@@ -941,8 +942,8 @@ public final @UsesObjectEquals class Files {
      *          method is invoked to check write access to the file.
      */
     @ReleasesNoLocks
-    public static Path createTempFile(String prefix,
-                                      String suffix,
+    public static Path createTempFile(@Nullable String prefix,
+                                      @Nullable String suffix,
                                       FileAttribute<?>... attrs)
         throws IOException
     {
@@ -996,7 +997,7 @@ public final @UsesObjectEquals class Files {
      */
     @ReleasesNoLocks
     public static Path createTempDirectory(Path dir,
-                                           String prefix,
+                                           @Nullable String prefix,
                                            FileAttribute<?>... attrs)
         throws IOException
     {
@@ -1038,7 +1039,7 @@ public final @UsesObjectEquals class Files {
      *          directory.
      */
     @ReleasesNoLocks
-    public static Path createTempDirectory(String prefix,
+    public static Path createTempDirectory(@Nullable String prefix,
                                            FileAttribute<?>... attrs)
         throws IOException
     {
@@ -1763,7 +1764,7 @@ public final @UsesObjectEquals class Files {
      *          permission required by a file type detector implementation.
      */
     @ReleasesNoLocks
-    public static String probeContentType(Path path)
+    public static @Nullable String probeContentType(Path path)
         throws IOException
     {
         // try installed file type detectors
@@ -1822,7 +1823,7 @@ public final @UsesObjectEquals class Files {
      *          the attribute view type is not available
      */
     @ReleasesNoLocks
-    public static <V extends FileAttributeView> V getFileAttributeView(Path path,
+    public static <V extends @Nullable FileAttributeView> V getFileAttributeView(Path path,
                                                                        Class<V> type,
                                                                        LinkOption... options)
     {

--- a/src/java.base/share/classes/java/nio/file/LinkPermission.java
+++ b/src/java.base/share/classes/java/nio/file/LinkPermission.java
@@ -27,6 +27,9 @@ package java.nio.file;
 
 import java.security.BasicPermission;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * The {@code Permission} class for link creation operations.
  *
@@ -66,6 +69,8 @@ import java.security.BasicPermission;
  * @see Files#createLink
  * @see Files#createSymbolicLink
  */
+
+@AnnotatedFor({"nullness"})
 public final class LinkPermission extends BasicPermission {
     @java.io.Serial
     static final long serialVersionUID = -1441492453772213220L;
@@ -102,7 +107,7 @@ public final class LinkPermission extends BasicPermission {
      * @throws  IllegalArgumentException
      *          if name is empty or invalid, or actions is a non-empty string
      */
-    public LinkPermission(String name, String actions) {
+    public LinkPermission(String name, @Nullable String actions) {
         super(name);
         checkName(name);
         if (actions != null && !actions.isEmpty()) {

--- a/src/java.base/share/classes/java/nio/file/SecureDirectoryStream.java
+++ b/src/java.base/share/classes/java/nio/file/SecureDirectoryStream.java
@@ -276,7 +276,7 @@ public interface SecureDirectoryStream<T>
      *          this directory stream, or {@code null} if the attribute view
      *          type is not available
      */
-    <V extends @Nullable FileAttributeView> V getFileAttributeView(Class<V> type);
+    <V extends FileAttributeView> @Nullable V getFileAttributeView(Class<V> type);
 
     /**
      * Returns a new file attribute view to access the file attributes of a file
@@ -311,7 +311,7 @@ public interface SecureDirectoryStream<T>
      *          type is not available
      *
      */
-    <V extends @Nullable FileAttributeView> V getFileAttributeView(T path,
+    <V extends FileAttributeView> @Nullable V getFileAttributeView(T path,
                                                          Class<V> type,
                                                          LinkOption... options);
 }

--- a/src/java.base/share/classes/java/nio/file/SecureDirectoryStream.java
+++ b/src/java.base/share/classes/java/nio/file/SecureDirectoryStream.java
@@ -29,6 +29,9 @@ import java.nio.channels.SeekableByteChannel;
 import java.util.Set;
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.AnnotatedFor;
+
 /**
  * A {@code DirectoryStream} that defines operations on files that are located
  * relative to an open directory. A {@code SecureDirectoryStream} is intended
@@ -55,6 +58,8 @@ import java.io.IOException;
  *
  * @since   1.7
  */
+
+@AnnotatedFor({"nullness"})
 
 public interface SecureDirectoryStream<T>
     extends DirectoryStream<T>
@@ -271,7 +276,7 @@ public interface SecureDirectoryStream<T>
      *          this directory stream, or {@code null} if the attribute view
      *          type is not available
      */
-    <V extends FileAttributeView> V getFileAttributeView(Class<V> type);
+    <V extends @Nullable FileAttributeView> V getFileAttributeView(Class<V> type);
 
     /**
      * Returns a new file attribute view to access the file attributes of a file
@@ -306,7 +311,7 @@ public interface SecureDirectoryStream<T>
      *          type is not available
      *
      */
-    <V extends FileAttributeView> V getFileAttributeView(T path,
+    <V extends @Nullable FileAttributeView> V getFileAttributeView(T path,
                                                          Class<V> type,
                                                          LinkOption... options);
 }

--- a/src/java.base/share/classes/java/nio/file/SimpleFileVisitor.java
+++ b/src/java.base/share/classes/java/nio/file/SimpleFileVisitor.java
@@ -26,6 +26,7 @@
 package java.nio.file;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.nio.file.attribute.BasicFileAttributes;
@@ -43,7 +44,7 @@ import java.util.Objects;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullness"})
 public @UsesObjectEquals class SimpleFileVisitor<T> implements FileVisitor<T> {
     /**
      * Initializes a new instance of this class.
@@ -105,7 +106,7 @@ public @UsesObjectEquals class SimpleFileVisitor<T> implements FileVisitor<T> {
      * of the directory to terminate prematurely.
      */
     @Override
-    public FileVisitResult postVisitDirectory(T dir, IOException exc)
+    public FileVisitResult postVisitDirectory(T dir, @Nullable IOException exc)
         throws IOException
     {
         Objects.requireNonNull(dir);

--- a/src/java.base/share/classes/java/nio/file/WatchEvent.java
+++ b/src/java.base/share/classes/java/nio/file/WatchEvent.java
@@ -25,6 +25,9 @@
 
 package java.nio.file;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * An event or a repeated event for an object that is registered with a {@link
  * WatchService}.
@@ -44,7 +47,8 @@ package java.nio.file;
  * @since 1.7
  */
 
-public interface WatchEvent<T> {
+@AnnotatedFor({"nullness"})
+public interface WatchEvent<T extends @Nullable Object> {
 
     /**
      * An event kind, for the purposes of identification.
@@ -52,7 +56,7 @@ public interface WatchEvent<T> {
      * @since 1.7
      * @see StandardWatchEventKinds
      */
-    public static interface Kind<T> {
+    public static interface Kind<T extends @Nullable Object> {
         /**
          * Returns the name of the event kind.
          *

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A watch service that <em>watches</em> registered objects for changes and
@@ -105,7 +106,7 @@ import org.checkerframework.framework.qual.AnnotatedFor;
  *
  * @see FileSystem#newWatchService
  */
-@AnnotatedFor({"mustcall"})
+@AnnotatedFor({"mustcall", "nullness"})
 @InheritableMustCall({})
 public interface WatchService
     extends Closeable
@@ -140,7 +141,7 @@ public interface WatchService
      * @throws  ClosedWatchServiceException
      *          if this watch service is closed
      */
-    WatchKey poll();
+    @Nullable WatchKey poll();
 
     /**
      * Retrieves and removes the next watch key, waiting if necessary up to the
@@ -160,7 +161,7 @@ public interface WatchService
      * @throws  InterruptedException
      *          if interrupted while waiting
      */
-    WatchKey poll(long timeout, TimeUnit unit)
+    @Nullable WatchKey poll(long timeout, TimeUnit unit)
         throws InterruptedException;
 
     /**

--- a/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributeView.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributeView.java
@@ -27,6 +27,9 @@ package java.nio.file.attribute;
 
 import java.io.IOException;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A file attribute view that provides a view of a <em>basic set</em> of file
  * attributes common to many file systems. The basic set of file attributes
@@ -101,6 +104,7 @@ import java.io.IOException;
  * @since 1.7
  */
 
+@AnnotatedFor({"nullness"})
 public interface BasicFileAttributeView
     extends FileAttributeView
 {
@@ -176,7 +180,7 @@ public interface BasicFileAttributeView
      *
      * @see java.nio.file.Files#setLastModifiedTime
      */
-    void setTimes(FileTime lastModifiedTime,
-                  FileTime lastAccessTime,
-                  FileTime createTime) throws IOException;
+    void setTimes(@Nullable FileTime lastModifiedTime,
+                  @Nullable FileTime lastAccessTime,
+                  @Nullable FileTime createTime) throws IOException;
 }

--- a/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributes.java
+++ b/src/java.base/share/classes/java/nio/file/attribute/BasicFileAttributes.java
@@ -27,6 +27,7 @@ package java.nio.file.attribute;
 
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.framework.qual.AnnotatedFor;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Basic attributes associated with a file in a file system.
@@ -46,7 +47,7 @@ import org.checkerframework.framework.qual.AnnotatedFor;
  * @see BasicFileAttributeView
  */
 
-@AnnotatedFor({"index"})
+@AnnotatedFor({"index", "nullness"})
 public interface BasicFileAttributes {
 
     /**
@@ -155,5 +156,5 @@ public interface BasicFileAttributes {
      *
      * @see java.nio.file.Files#walkFileTree
      */
-    Object fileKey();
+    @Nullable Object fileKey();
 }

--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -26,6 +26,7 @@
 package java.nio.file.spi;
 
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.nio.channels.AsynchronousFileChannel;
@@ -113,7 +114,7 @@ import sun.nio.ch.FileChannelImpl;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullness"})
 public abstract @UsesObjectEquals class FileSystemProvider {
     // lock using when loading providers
     private static final Object lock = new Object();
@@ -586,7 +587,7 @@ public abstract @UsesObjectEquals class FileSystemProvider {
      */
     public AsynchronousFileChannel newAsynchronousFileChannel(Path path,
                                                               Set<? extends OpenOption> options,
-                                                              ExecutorService executor,
+                                                              @Nullable ExecutorService executor,
                                                               FileAttribute<?>... attrs)
         throws IOException
     {
@@ -1074,7 +1075,7 @@ public abstract @UsesObjectEquals class FileSystemProvider {
      * @return  a file attribute view of the specified type, or {@code null} if
      *          the attribute view type is not available
      */
-    public abstract <V extends FileAttributeView> V
+    public abstract <V extends @Nullable FileAttributeView> V
         getFileAttributeView(Path path, Class<V> type, LinkOption... options);
 
     /**

--- a/src/java.base/share/classes/java/nio/file/spi/FileTypeDetector.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileTypeDetector.java
@@ -25,6 +25,7 @@
 
 package java.nio.file.spi;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
@@ -50,7 +51,7 @@ import java.io.IOException;
  * @since 1.7
  */
 
-@AnnotatedFor({"interning"})
+@AnnotatedFor({"interning", "nullable"})
 public abstract @UsesObjectEquals class FileTypeDetector {
 
     private static Void checkPermission() {
@@ -106,6 +107,6 @@ public abstract @UsesObjectEquals class FileTypeDetector {
      *
      * @see java.nio.file.Files#probeContentType
      */
-    public abstract String probeContentType(Path path)
+    public abstract @Nullable String probeContentType(Path path)
         throws IOException;
 }


### PR DESCRIPTION
While writing some java code I noticed some annotations where lacking for the NIO classes. In this PR I went through all classes in nio that mention `null` in the javadoc and annotated them.

With exception of the exceptions, those I kept in #233