### PR TITLE
Added null annotations for Field

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -445,7 +445,7 @@ class Field extends AccessibleObject implements Member {
     @SideEffectFree
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public @Nullable Object get(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public @Nullable Object get(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -480,7 +480,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public boolean getBoolean(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public boolean getBoolean(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -515,7 +515,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public byte getByte(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public byte getByte(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -552,7 +552,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public char getChar(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public char getChar(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -589,7 +589,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public short getShort(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public short getShort(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -626,7 +626,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public int getInt(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public int getInt(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -663,7 +663,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public long getLong(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public long getLong(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -700,7 +700,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public float getFloat(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public float getFloat(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -737,7 +737,7 @@ class Field extends AccessibleObject implements Member {
     @Pure
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public double getDouble(@GuardSatisfied Field this, @GuardSatisfied Object obj)
+    public double getDouble(@GuardSatisfied Field this, @GuardSatisfied @Nullable Object obj)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -827,7 +827,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void set(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, @GuardSatisfied @Interned Object value)
+    public void set(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, @GuardSatisfied @Interned Object value)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -864,7 +864,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setBoolean(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, boolean z)
+    public void setBoolean(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, boolean z)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -901,7 +901,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setByte(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, byte b)
+    public void setByte(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, byte b)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -938,7 +938,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setChar(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, char c)
+    public void setChar(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, char c)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -975,7 +975,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setShort(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, short s)
+    public void setShort(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, short s) 
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -1012,7 +1012,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setInt(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, int i)
+    public void setInt(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, int i)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -1049,7 +1049,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setLong(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, long l)
+    public void setLong(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, long l)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -1086,7 +1086,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setFloat(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, float f)
+    public void setFloat(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, float f)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {
@@ -1123,7 +1123,7 @@ class Field extends AccessibleObject implements Member {
      */
     @CallerSensitive
     @ForceInline // to ensure Reflection.getCallerClass optimization
-    public void setDouble(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization Object obj, double d)
+    public void setDouble(@GuardSatisfied Field this, @GuardSatisfied @UnknownInitialization @Nullable Object obj, double d)
         throws IllegalArgumentException, IllegalAccessException
     {
         if (!override) {


### PR DESCRIPTION
I've kept these changes in a separate PR, for one thing since I saw that in `AccessibleObject::canAccess` @cpovirk in https://github.com/typetools/jdk/commit/aadd76c54729f9abdac9a2410ae503298ac08974 added a comment about this, so this might be something where you want to be stricter?

As in, you can pass in a null if you're doing reflection to static fields/methods, but I guess it's more common that you intend to use it with an object instance?