### PR TITLE
Add MustCall annotations for JDBC ResultSet

### DIFF
--- a/src/java.desktop/share/classes/javax/sound/midi/MidiDevice.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/MidiDevice.java
@@ -27,6 +27,10 @@ package javax.sound.midi;
 
 import java.util.List;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+
 /**
  * {@code MidiDevice} is the base interface for all MIDI devices. Common devices
  * include synthesizers, sequencers, MIDI input ports, and MIDI output ports.
@@ -93,6 +97,8 @@ import java.util.List;
  * @see Receiver
  * @see Transmitter
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface MidiDevice extends AutoCloseable {
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/midi/Receiver.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Receiver.java
@@ -25,6 +25,9 @@
 
 package javax.sound.midi;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A {@code Receiver} receives {@link MidiEvent} objects and typically does
  * something useful in response, such as interpreting them to generate sound or
@@ -36,6 +39,8 @@ package javax.sound.midi;
  * @see Synthesizer
  * @see Transmitter
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Receiver extends AutoCloseable {
 
     //$$fb 2002-04-12: fix for 4662090: Contradiction in Receiver specification

--- a/src/java.desktop/share/classes/javax/sound/midi/Transmitter.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Transmitter.java
@@ -25,6 +25,9 @@
 
 package javax.sound.midi;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A {@code Transmitter} sends {@link MidiEvent} objects to one or more
  * {@link Receiver Receivers}. Common MIDI transmitters include sequencers and
@@ -33,6 +36,8 @@ package javax.sound.midi;
  * @author Kara Kytle
  * @see Receiver
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Transmitter extends AutoCloseable {
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/Line.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/Line.java
@@ -25,6 +25,9 @@
 
 package javax.sound.sampled;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * The {@code Line} interface represents a mono or multi-channel audio feed. A
  * line is an element of the digital audio "pipeline," such as a mixer, an input
@@ -66,6 +69,8 @@ package javax.sound.sampled;
  * @see LineEvent
  * @since 1.3
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Line extends AutoCloseable {
 
     /**

--- a/src/java.sql/share/classes/java/sql/ResultSet.java
+++ b/src/java.sql/share/classes/java/sql/ResultSet.java
@@ -26,6 +26,7 @@
 package java.sql;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.math.BigDecimal;
@@ -149,7 +150,8 @@ import java.io.InputStream;
  * @since 1.1
  */
 
-@AnnotatedFor("nullness")
+@AnnotatedFor({"nullness", "mustcall"})
+@InheritableMustCall("close")
 public interface ResultSet extends Wrapper, AutoCloseable {
 
     /**


### PR DESCRIPTION
This change enables MustCall checking for JDBC by annotating java.sql.ResultSet with @InheritableMustCall("close").

The annotation correctly models JDBC cursor lifecycle requirements and ensures that close() obligations are enforced by the Checker Framework. All RowSet interfaces and implementations inherit this behavior transitively