### PR TITLE
Add MustCall annotations to resource-owning JDBC, MIDI, and audio interfaces

### DIFF
--- a/src/java.desktop/share/classes/javax/sound/midi/MidiDevice.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/MidiDevice.java
@@ -27,6 +27,10 @@ package javax.sound.midi;
 
 import java.util.List;
 
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+
 /**
  * {@code MidiDevice} is the base interface for all MIDI devices. Common devices
  * include synthesizers, sequencers, MIDI input ports, and MIDI output ports.
@@ -93,6 +97,8 @@ import java.util.List;
  * @see Receiver
  * @see Transmitter
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface MidiDevice extends AutoCloseable {
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/midi/MidiDevice.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/MidiDevice.java
@@ -27,7 +27,7 @@ package javax.sound.midi;
 
 import java.util.List;
 
-import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 

--- a/src/java.desktop/share/classes/javax/sound/midi/Receiver.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Receiver.java
@@ -25,6 +25,9 @@
 
 package javax.sound.midi;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A {@code Receiver} receives {@link MidiEvent} objects and typically does
  * something useful in response, such as interpreting them to generate sound or
@@ -36,6 +39,8 @@ package javax.sound.midi;
  * @see Synthesizer
  * @see Transmitter
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Receiver extends AutoCloseable {
 
     //$$fb 2002-04-12: fix for 4662090: Contradiction in Receiver specification

--- a/src/java.desktop/share/classes/javax/sound/midi/Transmitter.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Transmitter.java
@@ -25,6 +25,9 @@
 
 package javax.sound.midi;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * A {@code Transmitter} sends {@link MidiEvent} objects to one or more
  * {@link Receiver Receivers}. Common MIDI transmitters include sequencers and
@@ -33,6 +36,8 @@ package javax.sound.midi;
  * @author Kara Kytle
  * @see Receiver
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Transmitter extends AutoCloseable {
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/Line.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/Line.java
@@ -25,6 +25,9 @@
 
 package javax.sound.sampled;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 /**
  * The {@code Line} interface represents a mono or multi-channel audio feed. A
  * line is an element of the digital audio "pipeline," such as a mixer, an input
@@ -66,6 +69,8 @@ package javax.sound.sampled;
  * @see LineEvent
  * @since 1.3
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Line extends AutoCloseable {
 
     /**

--- a/src/java.sql/share/classes/java/sql/ResultSet.java
+++ b/src/java.sql/share/classes/java/sql/ResultSet.java
@@ -26,7 +26,7 @@
 package java.sql;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.math.BigDecimal;

--- a/src/java.sql/share/classes/java/sql/ResultSet.java
+++ b/src/java.sql/share/classes/java/sql/ResultSet.java
@@ -26,6 +26,7 @@
 package java.sql;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.math.BigDecimal;
@@ -149,7 +150,8 @@ import java.io.InputStream;
  * @since 1.1
  */
 
-@AnnotatedFor("nullness")
+@AnnotatedFor({"nullness", "mustcall"})
+@InheritableMustCall("close")
 public interface ResultSet extends Wrapper, AutoCloseable {
 
     /**

--- a/src/java.sql/share/classes/java/sql/Statement.java
+++ b/src/java.sql/share/classes/java/sql/Statement.java
@@ -28,6 +28,9 @@ package java.sql;
 import org.checkerframework.checker.sqlquotes.qual.SqlEvenQuotes;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.util.regex.Pattern;
 import static java.util.stream.Collectors.joining;
 
@@ -47,6 +50,8 @@ import static java.util.stream.Collectors.joining;
  * @see ResultSet
  * @since 1.1
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Statement extends Wrapper, AutoCloseable {
 
     /**


### PR DESCRIPTION
Add MustCall annotations to core **JDBC**, **MIDI**, and **audio interfaces** that own native or external resources.
These annotations model required **close()** obligations and propagate correctly to all subinterfaces, enabling the MustCall Checker to detect resource leaks.

Related to https://github.com/typetools/checker-framework/issues/6354.