### PR TITLE
Add MustCall annotations to JDBC Statement and ResultSet

### DIFF
--- a/src/java.sql/share/classes/java/sql/ResultSet.java
+++ b/src/java.sql/share/classes/java/sql/ResultSet.java
@@ -26,6 +26,7 @@
 package java.sql;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.framework.qual.AnnotatedFor;
 
 import java.math.BigDecimal;
@@ -149,7 +150,8 @@ import java.io.InputStream;
  * @since 1.1
  */
 
-@AnnotatedFor("nullness")
+@AnnotatedFor({"nullness", "mustcall"})
+@InheritableMustCall("close")
 public interface ResultSet extends Wrapper, AutoCloseable {
 
     /**

--- a/src/java.sql/share/classes/java/sql/Statement.java
+++ b/src/java.sql/share/classes/java/sql/Statement.java
@@ -28,6 +28,9 @@ package java.sql;
 import org.checkerframework.checker.sqlquotes.qual.SqlEvenQuotes;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
 import java.util.regex.Pattern;
 import static java.util.stream.Collectors.joining;
 
@@ -47,6 +50,8 @@ import static java.util.stream.Collectors.joining;
  * @see ResultSet
  * @since 1.1
  */
+@AnnotatedFor({"mustcall"})
+@InheritableMustCall("close")
 public interface Statement extends Wrapper, AutoCloseable {
 
     /**


### PR DESCRIPTION
This PR adds `@InheritableMustCall("close")` annotations to the **JDBC** interfaces `Statement `and `ResultSet`.

These types represent database-backed resources whose lifecycle already requires callers to invoke `close().` Adding **MustCall** annotations enables the **MustCall** Checker to detect resource leaks in common **JDBC** usage patterns while refining the existing **AutoCloseable** contract.

This PR contributes to https://github.com/typetools/checker-framework/issues/6354
 by annotating additional **JDK** subtypes of **AutoCloseable** that own external resources.

Related tests are provided in https://github.com/typetools/checker-framework/pull/7480
.

This PR intentionally includes only **JDBC** types. **Audio/MIDI** annotations from the original PR are being handled separately because their lifecycle semantics are more complex.